### PR TITLE
Add tests for remaining aws integrations

### DIFF
--- a/api/v1/datadog/api_aws_integration_test.go
+++ b/api/v1/datadog/api_aws_integration_test.go
@@ -39,7 +39,7 @@ func TestCreateAWSAccount(t *testing.T) {
 	// Assert AWS Integration Created with proper fields
 	_, httpresp, err := TESTAPICLIENT.AWSIntegrationApi.CreateAWSAccount(TESTAUTH).AwsAccount(testAwsAccount).Execute()
 	if err != nil {
-		t.Errorf("Error creating AWS Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
+		t.Fatalf("Error creating AWS Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
 	}
 	assert.Equal(t, httpresp.StatusCode, 200)
 	defer uninstallAWSIntegration(testAwsAccount)
@@ -50,7 +50,7 @@ func TestCreateAWSAccount(t *testing.T) {
 		RoleName(testAwsAccount.GetRoleName()).
 		Execute()
 	if err != nil {
-		t.Errorf("Error getting AWS Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
+		t.Fatalf("Error getting AWS Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
 	}
 	assert.Equal(t, httpresp.StatusCode, 200)
 
@@ -87,7 +87,7 @@ func TestUpdateAWSAccount(t *testing.T) {
 		RoleName(testAwsAccount.GetRoleName()).
 		Execute()
 	if err != nil {
-		t.Errorf("Error updating AWS Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
+		t.Fatalf("Error updating AWS Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
 	}
 	assert.Equal(t, httpresp.StatusCode, 200)
 	UPDATEDAWSACCT := datadog.AwsAccount{
@@ -102,7 +102,7 @@ func TestUpdateAWSAccount(t *testing.T) {
 		RoleName(UPDATEDAWSACCT.GetRoleName()).
 		Execute()
 	if err != nil {
-		t.Errorf("Error getting AWS Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
+		t.Fatalf("Error getting AWS Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
 	}
 	assert.Equal(t, httpresp.StatusCode, 200)
 
@@ -125,7 +125,7 @@ func TestDisableAWSAcct(t *testing.T) {
 	// Lets first create the account of us to delete
 	_, httpresp, err := TESTAPICLIENT.AWSIntegrationApi.CreateAWSAccount(TESTAUTH).AwsAccount(testAwsAccount).Execute()
 	if err != nil {
-		t.Errorf("Error creating AWS Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
+		t.Fatalf("Error creating AWS Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
 	}
 	assert.Equal(t, httpresp.StatusCode, 200)
 	defer uninstallAWSIntegration(testAwsAccount)
@@ -141,12 +141,14 @@ func TestGenerateNewExternalId(t *testing.T) {
 	testAwsAccount := generateUniqueAwsAccount()
 	// Lets first create the account for us to generate a new id against
 	_, httpresp, err := TESTAPICLIENT.AWSIntegrationApi.CreateAWSAccount(TESTAUTH).AwsAccount(testAwsAccount).Execute()
-	if err != nil || httpresp.StatusCode != 200 {
+	if err != nil {
 		t.Fatalf("Error creating AWS Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
 	}
+	assert.Equal(t, httpresp.StatusCode, 200)
+
 	apiResp, httpresp, err := TESTAPICLIENT.AWSIntegrationApi.GenerateNewAWSExternalID(TESTAUTH).AwsAccount(testAwsAccount).Execute()
 	if err != nil {
-		t.Fatalf("Error generating new AWS External ID %v", err)
+		t.Fatalf("Error generating new AWS External ID: Response: %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
 	}
 	assert.Equal(t, httpresp.StatusCode, 200)
 	assert.Assert(t, apiResp.GetExternalId() != "")
@@ -155,7 +157,7 @@ func TestGenerateNewExternalId(t *testing.T) {
 func TestListNamespaces(t *testing.T) {
 	namespaces, httpresp, err := TESTAPICLIENT.AWSIntegrationApi.ListAvailableAWSNamespaces(TESTAUTH).Execute()
 	if err != nil {
-		t.Fatalf("Error listing AWS Namespaces %v", err)
+		t.Fatalf("Error listing AWS Namespaces: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
 	}
 	assert.Equal(t, httpresp.StatusCode, 200)
 	namespacesCheck := make(map[string]bool)

--- a/api/v1/datadog/api_azure_integration_test.go
+++ b/api/v1/datadog/api_azure_integration_test.go
@@ -45,7 +45,7 @@ func TestAzureCreate(t *testing.T) {
 
 	_, httpresp, err := TESTAPICLIENT.AzureIntegrationApi.CreateAzureIntegration(TESTAUTH).AzureAccount(testAzureAcct).Execute()
 	if err != nil {
-		t.Errorf("Error creating Azure Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
+		t.Fatalf("Error creating Azure Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
 	}
 	assert.Equal(t, httpresp.StatusCode, 200)
 }
@@ -85,7 +85,7 @@ func TestAzureListandDelete(t *testing.T) {
 	// Test account deletion as well
 	_, httpresp, err = TESTAPICLIENT.AzureIntegrationApi.DeleteAzureIntegration(TESTAUTH).AzureAccount(testAzureAcct).Execute()
 	if err != nil {
-		t.Errorf("Error deleting Azure Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
+		t.Fatalf("Error deleting Azure Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
 	}
 	assert.Equal(t, httpresp.StatusCode, 200)
 }
@@ -107,7 +107,7 @@ func TestUpdateAzureAccount(t *testing.T) {
 	_, httpresp, err = TESTAPICLIENT.AzureIntegrationApi.UpdateAzureIntegration(TESTAUTH).AzureAccount(testUpdateAzureAcct).Execute()
 	defer uninstallAzureIntegration(testUpdateAzureAcct)
 	if err != nil {
-		t.Errorf("Error updating Azure Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
+		t.Fatalf("Error updating Azure Account: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
 	}
 
 	assert.Equal(t, httpresp.StatusCode, 200)
@@ -115,7 +115,7 @@ func TestUpdateAzureAccount(t *testing.T) {
 	// List account to ensure update worked.
 	azureListOutput, _, err := TESTAPICLIENT.AzureIntegrationApi.ListAzureIntegration(TESTAUTH).Execute()
 	if err != nil {
-		t.Errorf("Error listing Azure Accounts: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
+		t.Fatalf("Error listing Azure Accounts: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
 	}
 	assert.Equal(t, httpresp.StatusCode, 200)
 	var x datadog.AzureAccount
@@ -131,12 +131,12 @@ func TestUpdateAzureAccount(t *testing.T) {
 	// Test update host filters endpoint
 	_, httpresp, err = TESTAPICLIENT.AzureIntegrationApi.AzureUpdateHostFilters(TESTAUTH).AzureAccount(testAzureUpdateHostFilters).Execute()
 	if err != nil {
-		t.Errorf("Error updating Azure Host Filters: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
+		t.Fatalf("Error updating Azure Host Filters: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
 	}
 	assert.Equal(t, httpresp.StatusCode, 200)
 	HFListOutput, httpresp, err := TESTAPICLIENT.AzureIntegrationApi.ListAzureIntegration(TESTAUTH).Execute()
 	if err != nil {
-		t.Errorf("Error listing Azure Accounts: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
+		t.Fatalf("Error listing Azure Accounts: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
 	}
 	assert.Equal(t, httpresp.StatusCode, 200)
 	var y datadog.AzureAccount

--- a/api/v1/datadog/api_gcp_integration_test.go
+++ b/api/v1/datadog/api_gcp_integration_test.go
@@ -107,14 +107,14 @@ func TestUpdateGcpAccount(t *testing.T) {
 
 	_, httpresp, err = TESTAPICLIENT.GCPIntegrationApi.UpdateGCPIntegration(TESTAUTH).GcpAccount(testGCPUpdateAcct).Execute()
 	if err != nil {
-		t.Errorf("Error updating GCP integration: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
+		t.Fatalf("Error updating GCP integration: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
 	}
 	assert.Equal(t, httpresp.StatusCode, 200)
 
 	// List account to ensure update worked.
 	gcpListOutput, _, err := TESTAPICLIENT.GCPIntegrationApi.ListGCPIntegration(TESTAUTH).Execute()
 	if err != nil {
-		t.Errorf("Error listing GCP accounts: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
+		t.Fatalf("Error listing GCP accounts: Response %s: %v", err.(datadog.GenericOpenAPIError).Body(), err)
 	}
 	assert.Equal(t, httpresp.StatusCode, 200)
 	var x datadog.GcpAccount


### PR DESCRIPTION
Adds small tests for the `generate new external id` and `list namespaces`  and two logs async endpoints that are now generated. 

Also addresses missed review from - https://github.com/DataDog/datadog-api-client-go/pull/32

Also uses the updated schema that uses the more standard `Request/Response` instead of `Input/Output`