### PR TITLE
Fix flaky log timestamp

### DIFF
--- a/api/v1/datadog/api_logs_test.go
+++ b/api/v1/datadog/api_logs_test.go
@@ -42,7 +42,7 @@ func TestLogsList(t *testing.T) {
 		Ddsource: &source,
 		Ddtags:   datadog.PtrString("go,test,list"),
 		Hostname: &hostname,
-		Message:  &message,
+		Message:  datadog.PtrString(fmt.Sprintf(`{"timestamp": %d, "message": "%s"}`, (now.Unix()-1)*1000, message)),
 	}
 
 	// Create log entry
@@ -52,8 +52,8 @@ func TestLogsList(t *testing.T) {
 	}
 	assert.Equal(t, httpresp.StatusCode, 200)
 
-	secondMessage := "second-" + message
-	httpLog.SetMessage(secondMessage)
+	secondMessage := fmt.Sprintf("second-test-log-list-%d", nanoNow)
+	httpLog.SetMessage(fmt.Sprintf(`{"timestamp": %d, "message": "%s"}`, (now.Unix())*1000, secondMessage))
 
 	// Create second log entry
 	_, httpresp, err = TESTAPICLIENT.LogsApi.SendLog(TESTAUTH).Body(httpLog).Execute()


### PR DESCRIPTION
### What does this PR do?

Uses `timestamp` in the message to avoid flaky index time.


### Description of the Change

<!--

A brief description of the change being made with this pull request.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

Thanks @zippolyte 

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
