### PR TITLE
Update CI to run every 6 hours

### DIFF
--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -11,6 +11,7 @@ pr:
 schedules:
   - cron: "0 */6 * * *"
     displayName: Scheduled CI run every 6 hours
+    always: true
     branches:
       include:
         - master


### PR DESCRIPTION
### Requirements for Contributing to this repository

### What does this PR do?

This PR updates the cron schedule for the AZP trigger to run every 6 hours.

### Alternate Designs
I considered using `always: False` - https://docs.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml, which runs the CI only if source code has changed. But I think we'll want to run the CI regardless if the code has changed since the last run for now. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
