### PR TITLE
Enable running tests against API without recording cassettes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,7 +29,7 @@ Tests for a single file or method can be executed via:
  go test -v -run <NAME_OF_FAILING_TEST> ./tests/api/v1/datadog
 ```
 
-By default integration tests use recorded API responses stored in cassettes. To record new API responses run the tests with `RECORD=true`.
+By default integration tests use recorded API responses stored in cassettes. To record new API responses run the tests with `RECORD=true`. To run integration tests against API without recording cassettes, run the tests with `RECORD=none`.
 
 **IMPORTANT**: 
 When creating a PR that adds or updates a test, __never__ commit 

--- a/tests/api/v1/datadog/api_key_management_test.go
+++ b/tests/api/v1/datadog/api_key_management_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestApiKeyFunctions(t *testing.T) {
-	if !tests.IsRecording() {
+	if tests.GetRecording() == tests.ModeReplaying {
 		t.Skip("This test case does not support reply from recording")
 	}
 
@@ -131,7 +131,7 @@ func TestApiKeyFunctions(t *testing.T) {
 }
 
 func TestApplicationKeyFunctions(t *testing.T) {
-	if !tests.IsRecording() {
+	if tests.GetRecording() == tests.ModeReplaying {
 		t.Skip("This test case does not support reply from recording")
 	}
 
@@ -452,7 +452,7 @@ func TestAppKeysMgmtCreateErrors(t *testing.T) {
 }
 
 func TestAppKeysMgmtCreate409Error(t *testing.T) {
-	if !tests.IsRecording() {
+	if tests.GetRecording() == tests.ModeReplaying {
 		t.Skip("This test case does not support reply from recording")
 	}
 
@@ -535,7 +535,7 @@ func TestAppKeysMgmtUpdateErrors(t *testing.T) {
 }
 
 func TestAppKeysMgmtUpdate409Error(t *testing.T) {
-	if !tests.IsRecording() {
+	if tests.GetRecording() == tests.ModeReplaying {
 		t.Skip("This test case does not support reply from recording")
 	}
 

--- a/tests/api/v1/datadog/api_users_test.go
+++ b/tests/api/v1/datadog/api_users_test.go
@@ -133,7 +133,7 @@ func TestDisableUser(t *testing.T) {
 }
 
 func TestListUsers(t *testing.T) {
-	if !tests.IsRecording() {
+	if tests.GetRecording() == tests.ModeReplaying {
 		t.Skip("This test case does not support reply from recording")
 	}
 

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -55,11 +55,6 @@ func GetRecording() RecordingMode {
 	}
 }
 
-// IsRecording returns true if the recording mode is enabled
-func IsRecording() bool {
-	return GetRecording() == ModeRecording
-}
-
 // IsCIRun returns true if the CI environment variable is set to "true"
 func IsCIRun() bool {
 	return os.Getenv("CI") == "true"
@@ -71,7 +66,7 @@ func Retry(interval time.Duration, count int, call func() bool) error {
 		if call() {
 			return nil
 		}
-		if IsRecording() {
+		if GetRecording() != ModeReplaying {
 			time.Sleep(interval)
 		}
 	}
@@ -93,7 +88,7 @@ func ReadFixture(path string) (string, error) {
 
 // ConfigureTracer starts the tracer.
 func ConfigureTracer(m *testing.M) {
-	if !IsRecording() {
+	if GetRecording() == ModeReplaying {
 		os.Exit(m.Run())
 	}
 	service, ok := os.LookupEnv("DD_SERVICE")
@@ -132,15 +127,17 @@ func createWithDir(path string) (*os.File, error) {
 // SetClock stores current time in .freeze file.
 func SetClock(t *testing.T) clockwork.FakeClock {
 	t.Helper()
-	os.MkdirAll("cassettes", 0755)
-
-	f, err := createWithDir(fmt.Sprintf("cassettes/%s.freeze", t.Name()))
-	if err != nil {
-		t.Fatalf("Could not set clock: %v", err)
-	}
-	defer f.Close()
 	now := clockwork.NewRealClock().Now()
-	f.WriteString(now.Format(time.RFC3339Nano))
+	if GetRecording() == ModeRecording {
+		os.MkdirAll("cassettes", 0755)
+
+		f, err := createWithDir(fmt.Sprintf("cassettes/%s.freeze", t.Name()))
+		if err != nil {
+			t.Fatalf("Could not set clock: %v", err)
+		}
+		defer f.Close()
+		f.WriteString(now.Format(time.RFC3339Nano))
+	}
 	return clockwork.NewFakeClockAt(now)
 }
 
@@ -168,7 +165,7 @@ var (
 func WithClock(ctx context.Context, t *testing.T) context.Context {
 	t.Helper()
 	var fc clockwork.FakeClock
-	if IsRecording() {
+	if GetRecording() != ModeReplaying {
 		fc = SetClock(t)
 	} else {
 		fc = RestoreClock(t)
@@ -236,10 +233,13 @@ func Recorder(ctx context.Context, t *testing.T) (*recorder.Recorder, error) {
 	t.Helper()
 	// Configure recorder
 	var mode recorder.Mode
-	if IsRecording() {
-		mode = recorder.ModeRecording
-	} else {
+	switch GetRecording() {
+	case ModeReplaying:
 		mode = recorder.ModeReplaying
+	case ModeIgnore:
+		mode = recorder.ModeDisabled
+	default:
+		mode = recorder.ModeRecording
 	}
 
 	r, err := recorder.NewAsMode(fmt.Sprintf("cassettes/%s", t.Name()), mode, nil)
@@ -259,7 +259,7 @@ func Recorder(ctx context.Context, t *testing.T) (*recorder.Recorder, error) {
 
 // WrapRoundTripper includes tracing information.
 func WrapRoundTripper(rt http.RoundTripper, opts ...ddhttp.RoundTripperOption) http.RoundTripper {
-	if !IsRecording() {
+	if GetRecording() == ModeReplaying {
 		return rt
 	}
 	return ddhttp.WrapRoundTripper(


### PR DESCRIPTION
### What does this PR do?

This PR makes `RECORD` properly recognize 3 different values:

* `true` - to run tests against API and record responses
* `false` (this is still the default) - to run tests against cassettes
* `none` - to run tests against API and not touch cassettes

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
