### PR TITLE
Fix a potential sigsegv in logs test which happens when API doesn't return expected result

### DIFF
--- a/tests/api/v1/datadog/api_logs_test.go
+++ b/tests/api/v1/datadog/api_logs_test.go
@@ -86,6 +86,7 @@ func TestLogsList(t *testing.T) {
 	}
 
 	// Find second log item
+	assert.NotNil(*logsResponse.NextLogId)
 	assert.True(len(*logsResponse.NextLogId) > 0)
 	logsRequest.SetStartAt(logsResponse.GetNextLogId())
 


### PR DESCRIPTION

### What does this PR do?

If there's no `NextLogId` in the response, we don't want to get sigsegv.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
