### PR TITLE
add handling in bdd runner for unstable operations

### DIFF
--- a/tests/api/v2/datadog/scenarios_test.go
+++ b/tests/api/v2/datadog/scenarios_test.go
@@ -161,7 +161,7 @@ func anInstanceOf(t gobdd.StepTest, ctx gobdd.Context, name string) {
 	tests.SetAPI(ctx, f)
 }
 
-// enableOperations sets API callable to apiKey{}
+// enableOperations sets unstable operations specific in this clause to enabled
 func enableOperations(t gobdd.StepTest, ctx gobdd.Context, name string) {
 	client := Client(tests.GetCtx(ctx))
 	client.GetConfig().SetUnstableOperationEnabled(name, true)

--- a/tests/api/v2/datadog/scenarios_test.go
+++ b/tests/api/v2/datadog/scenarios_test.go
@@ -38,7 +38,6 @@ var requestsUndo = map[string]func(ctx gobdd.Context){
 	"DisableUser":              undoIgnore,
 	"DeleteRole":               undoIgnore,
 	"GetInvitation":            undoIgnore,
-	"GetServices":              undoIgnore,
 	"GetRole":                  undoIgnore,
 	"GetUser":                  undoIgnore,
 	"ListPermissions":          undoIgnore,

--- a/tests/api/v2/datadog/scenarios_test.go
+++ b/tests/api/v2/datadog/scenarios_test.go
@@ -38,6 +38,7 @@ var requestsUndo = map[string]func(ctx gobdd.Context){
 	"DisableUser":              undoIgnore,
 	"DeleteRole":               undoIgnore,
 	"GetInvitation":            undoIgnore,
+	"GetServices":              undoIgnore,
 	"GetRole":                  undoIgnore,
 	"GetUser":                  undoIgnore,
 	"ListPermissions":          undoIgnore,
@@ -112,6 +113,7 @@ func TestScenarios(t *testing.T) {
 	s.AddStep(`a valid "apiKeyAuth" key in the system`, aValidAPIKeyAuth)
 	s.AddStep(`a valid "appKeyAuth" key in the system`, aValidAppKeyAuth)
 	s.AddStep(`an instance of "([^"]+)" API`, anInstanceOf)
+	s.AddStep(`operation "([^"]+)" enabled`, enableOperations)
 	s.AddStep(`there is a valid "user" in the system`, user)
 	s.AddStep(`there is a valid "role" in the system`, role)
 	s.AddStep(`the "user" has the "role"`, userHasRole)
@@ -158,6 +160,12 @@ func anInstanceOf(t gobdd.StepTest, ctx gobdd.Context, name string) {
 		panic(fmt.Sprintf("invalid API name %s", name))
 	}
 	tests.SetAPI(ctx, f)
+}
+
+// enableOperations sets API callable to apiKey{}
+func enableOperations(t gobdd.StepTest, ctx gobdd.Context, name string) {
+	client := Client(tests.GetCtx(ctx))
+	client.GetConfig().SetUnstableOperationEnabled(name, true)
 }
 
 func user(t gobdd.StepTest, ctx gobdd.Context) {


### PR DESCRIPTION
### What does this PR do?
- adds a handling for BDD "given" clauses that enable unstable operations
  - this is necessary to support BDD testing for unstable endpoints being added for incident management

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist
Please check relevant items below:
- [x] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [x] This PR does not rely on API client schema changes.
    - [x] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
