### PR TITLE
Add endpoint to reorder Logs Archives - tests

### DIFF
--- a/tests/api/v2/datadog/api_logs_archives_test.go
+++ b/tests/api/v2/datadog/api_logs_archives_test.go
@@ -217,6 +217,70 @@ func TestLogsArchivesGetAll(t *testing.T) {
 	assert.Equal(*outputArchives.Get(), result)
 }
 
+func TestGetLogsArchiveOrder(t *testing.T) {
+	ctx, finish := WithClient(WithFakeAuth(context.Background()), t)
+	defer finish()
+	client := Client(ctx)
+	assert := tests.Assert(ctx, t)
+
+	fileName := "default"
+	outputArchiveOrderStr := readFixture(t, fmt.Sprintf("fixtures/logs/archive_order/out/%s.json", fileName))
+	outputArchiveOrder := datadog.NullableLogsArchiveOrder{}
+	_ = outputArchiveOrder.UnmarshalJSON([]byte(outputArchiveOrderStr))
+
+	URL, err := Client(ctx).GetConfig().ServerURLWithContext(ctx, "LogsArchivesApiService.GetLogsArchiveOrder")
+	assert.NoError(err)
+	gock.New(URL).Get("/api/v2/logs/config/archive-order").Reply(200).Type("json").JSON(outputArchiveOrderStr)
+	defer gock.Off()
+	result, httpresp, err := client.LogsArchivesApi.GetLogsArchiveOrder(ctx).Execute()
+	assert.NoError(err)
+	assert.Equal(httpresp.StatusCode, 200)
+	assert.Equal(*outputArchiveOrder.Get(), result)
+
+}
+
+func TestUpdateLogsArchiveOrder(t *testing.T) {
+	ctx, finish := WithClient(WithFakeAuth(context.Background()), t)
+	defer finish()
+	client := Client(ctx)
+	assert := tests.Assert(ctx, t)
+	input := createUpdatedLogsArchiveOrder(t)
+
+	fileName := "updated"
+	outputArchiveOrderStr := readFixture(t, fmt.Sprintf("fixtures/logs/archive_order/out/%s.json", fileName))
+	outputArchiveOrder := datadog.NullableLogsArchiveOrder{}
+	_ = outputArchiveOrder.UnmarshalJSON([]byte(outputArchiveOrderStr))
+
+	URL, err := Client(ctx).GetConfig().ServerURLWithContext(ctx, "LogsArchivesApiService.GetLogsArchiveOrder")
+	assert.NoError(err)
+	gock.New(URL).Put("/api/v2/logs/config/archive-order").Reply(200).Type("json").JSON(outputArchiveOrderStr)
+	defer gock.Off()
+	result, httpresp, err := client.LogsArchivesApi.UpdateLogsArchiveOrder(ctx).Body(*input).Execute()
+	assert.NoError(err)
+	assert.Equal(httpresp.StatusCode, 200)
+	assert.Equal(*outputArchiveOrder.Get(), result)
+}
+
+func createUpdatedLogsArchiveOrder(t *testing.T) *datadog.LogsArchiveOrder {
+	fileName := "updated"
+	oldArchiveOrderStr := readFixture(t, fmt.Sprintf("fixtures/logs/archive_order/out/%s.json", fileName))
+	oldArchiveOrder := datadog.NullableLogsArchiveOrder{}
+	_ = oldArchiveOrder.UnmarshalJSON([]byte(oldArchiveOrderStr))
+	data := oldArchiveOrder.Get().GetData()
+	attributes := data.GetAttributes()
+	archiveIds := attributes.GetArchiveIds()
+	archiveIds = append(archiveIds, archiveIds[0])
+	archiveIds = append(archiveIds[:1], archiveIds[2:]...)
+
+	archiveOrderAttribute := datadog.NewLogsArchiveOrderAttributesWithDefaults()
+	archiveOrderAttribute.SetArchiveIds(archiveIds)
+	archiveOrderDefinition := datadog.NewLogsArchiveOrderDefinitionWithDefaults()
+	archiveOrderDefinition.SetAttributes(*archiveOrderAttribute)
+	newArchiveOrder := datadog.NewLogsArchiveOrderWithDefaults()
+	newArchiveOrder.SetData(*archiveOrderDefinition)
+	return newArchiveOrder
+}
+
 func readFixture(t *testing.T, path string) string {
 	t.Helper()
 	res, err := tests.ReadFixture(path)

--- a/tests/api/v2/datadog/fixtures/logs/archive_order/out/default.json
+++ b/tests/api/v2/datadog/fixtures/logs/archive_order/out/default.json
@@ -1,0 +1,1 @@
+{"data":{"attributes":{"archive_ids":["a2zcMylnM4OCHpYusxIi1g","a2zcMylnM4OCHpYusxIi2g","a2zcMylnM4OCHpYusxIi3g"]},"type":"archive_order"}}

--- a/tests/api/v2/datadog/fixtures/logs/archive_order/out/updated.json
+++ b/tests/api/v2/datadog/fixtures/logs/archive_order/out/updated.json
@@ -1,0 +1,1 @@
+{"data":{"attributes":{"archive_ids":["a2zcMylnM4OCHpYusxIi2g","a2zcMylnM4OCHpYusxIi3g","a2zcMylnM4OCHpYusxIi1g"]},"type":"archive_order"}}


### PR DESCRIPTION
<!--
** Requirements for Contributing to this repository **

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely 
manner may be closed at the maintainers' discretion.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. 
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?
add some tests in a new API endpoint to reorder archives. 
Related to PR 528 in api-spec
<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." 
If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [x] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
