### PR TITLE
Ensure test name only has underscores

### DIFF
--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -347,6 +347,9 @@ func WithUniqueSurrounding(ctx context.Context, name string) string {
 		buildID = "local"
 	}
 
+	// Replace all - with _ in the test name (scenario test names can include -)
+	name = strings.ReplaceAll(name, "-", "_")
+
 	// NOTE: some endpoints have limits on certain fields (e.g. Roles V2 names can only be 55 chars long),
 	// so we need to keep this short
 	result := fmt.Sprintf("go-%s-%s-%d", SecurePath(name), buildID, ClockFromContext(ctx).Now().Unix())


### PR DESCRIPTION
Test names must follow the pattern:: `go-%s-%s-%d` so that we can properly delete them. 
It looks like scenario tests can have a combination of dashes and underscores,  breaking the regex we're expecting. For example, one of the test names is:

```go-TestScenarios_Feature_Incident_Teams_Scenario_Get_a_list_of_all_incident_teams_returns__OK__response_Given_there_is_a_valid__team__in_the_system-29707-1604027001```

Converting the name to use underscores properly matches the regex we're expecting. 