### PR TITLE
Update Dashboard widgets data source (event_query, legacy_event_query)

### DIFF
--- a/tests/api/v1/datadog/api_dashboards_test.go
+++ b/tests/api/v1/datadog/api_dashboards_test.go
@@ -575,7 +575,7 @@ func TestDashboardLifecycle(t *testing.T) {
 
 	timeseriesWidgetProcessQuery := datadog.NewWidget(datadog.TimeseriesWidgetDefinitionAsWidgetDefinition(timeseriesWidgetDefinitionProcessQuery))
 
-	// Timeseries Widget with Log query (APM/Log/Network/Rum share schemas, so only test one)
+	// Timeseries Widget with Log query (APM/Log/Network/Rum/Event share schemas, so only test one)
 	timeseriesWidgetDefinitionLogQuery := datadog.NewTimeseriesWidgetDefinitionWithDefaults()
 	timeseriesWidgetDefinitionLogQuery.SetRequests([]datadog.TimeseriesWidgetRequest{{
 		LogQuery: &datadog.LogQueryDefinition{
@@ -631,10 +631,10 @@ func TestDashboardLifecycle(t *testing.T) {
 
 	timeseriesWidgetLogQuery := datadog.NewWidget(datadog.TimeseriesWidgetDefinitionAsWidgetDefinition(timeseriesWidgetDefinitionLogQuery))
 
-	// Timeseries Widget with Event query
+	// Timeseries Widget with Legacy Event query
 	timeseriesWidgetDefinitionEventQuery := datadog.NewTimeseriesWidgetDefinitionWithDefaults()
 	timeseriesWidgetDefinitionEventQuery.SetRequests([]datadog.TimeseriesWidgetRequest{{
-		EventQuery: &datadog.EventQueryDefinition{
+		LegacyEventQuery: &datadog.EventQueryDefinition{
 			Search:        "Build failure",
 			TagsExecution: "build",
 		},


### PR DESCRIPTION
<!--
** Requirements for Contributing to this repository **

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely 
manner may be closed at the maintainers' discretion.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. 
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->
### What does this PR do?
This PR introduces legacy_event_query data source based on Event Query Definition.
event_query move from Event Query Definition based on Log Query Definition.

Widgets impacted:

ChangeWidget
HostMapWidget
QueryValueWidget
ScatterPlotWidget
TableWidget
TopListWidget
HeatMapWidget
DistributionWidget
TimeseriesWidget
<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." 
If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->
This introduce a breaking change in the API definition, but event_query data source was not used for those widgets.


### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
