### PR TITLE
Skip host tags functional tests in ignore mode

### DIFF
--- a/tests/api/v1/datadog/api_hosts_test.go
+++ b/tests/api/v1/datadog/api_hosts_test.go
@@ -533,6 +533,10 @@ func TestHostsSearchMockedIncludeHostsMetadataDefault(t *testing.T) {
 }
 
 func TestHostsIncludeMutedHostsDataFunctional(t *testing.T) {
+	if tests.GetRecording() == tests.ModeIgnore {
+		t.Skipf("Slow test")
+	}
+
 	ctx, finish := WithRecorder(WithTestAuth(context.Background()), t)
 	defer finish()
 	assert := tests.Assert(ctx, t)

--- a/tests/api/v1/datadog/api_tags_test.go
+++ b/tests/api/v1/datadog/api_tags_test.go
@@ -19,6 +19,9 @@ import (
 )
 
 func TestTags(t *testing.T) {
+	if tests.GetRecording() == tests.ModeIgnore {
+		t.Skipf("Slow test")
+	}
 	ctx, finish := WithRecorder(WithTestAuth(context.Background()), t)
 	defer finish()
 	assert := tests.Assert(ctx, t)


### PR DESCRIPTION
Those tests are particularly slow, this should speed up integration tests quite a bit.