### PR TITLE
Quote copyright for names with commas

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -4,7 +4,7 @@ go.sum,github.com/aslakhellesoy/gox,MPL-2.0,The gox authors
 go.sum,github.com/creack/pty,MIT,2011 Keith Rarick
 go.sum,github.com/cucumber/gherkin-go/v13,MIT,Cucumber Ltd + Gaspar Nagy + Björn Rasmusson + Peter Sergeant
 go.sum,github.com/cucumber/messages-go/v12,MIT,Cucumber Ltd
-go.sum,github.com/DataDog/datadog-go,Apache-2.0,2016-Present Datadog, Inc.
+go.sum,github.com/DataDog/datadog-go,Apache-2.0,"2016-Present Datadog, Inc".
 go.sum,github.com/davecgh/go-spew,ISC,2012-2016 Dave Collins <dave@davec.name>
 go.sum,github.com/dnaeon/go-vcr,BSD-2-Clause,2015-2016 Marin Atanasov Nikolov <dnaeon@gmail.com>
 go.sum,github.com/go-bdd/assert,MIT, 2020 GoBDD
@@ -41,8 +41,8 @@ go.sum,golang.org/x/tools,BSD-3-Clause,2019 The Go Authors
 go.sum,golang.org/x/xerrors,BSD-3-Clause,2019 The Go Authors
 go.sum,google.golang.org/appengine,Apache-2.0,Google Inc.
 go.sum,gopkg.in/check.v1,BSD-2-Clause,2010-2013 Gustavo Niemeyer <gustavo@niemeyer.net>
-go.sum,gopkg.in/DataDog/dd-trace-go.v1,Apache-2.0,2016-Present Datadog, Inc.
-go.sum,github.com/DataDog/dd-trace-go,Apache-2.0,2016-Present Datadog, Inc.
+go.sum,gopkg.in/DataDog/dd-trace-go.v1,Apache-2.0,"2016-Present Datadog, Inc".
+go.sum,github.com/DataDog/dd-trace-go,Apache-2.0,"2016-Present Datadog, Inc".
 go.sum,gopkg.in/h2non/gock.v1,MIT,2016-2019 Tomas Aparicio
 go.sum,gopkg.in/yaml.v2,Apache-2.0,2011-2016 Canonical Ltd.
 go.sum,gotest.tools,Apache-2.0,2018 gotest.tools authors

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -4,7 +4,7 @@ go.sum,github.com/aslakhellesoy/gox,MPL-2.0,The gox authors
 go.sum,github.com/creack/pty,MIT,2011 Keith Rarick
 go.sum,github.com/cucumber/gherkin-go/v13,MIT,Cucumber Ltd + Gaspar Nagy + Björn Rasmusson + Peter Sergeant
 go.sum,github.com/cucumber/messages-go/v12,MIT,Cucumber Ltd
-go.sum,github.com/DataDog/datadog-go,Apache-2.0,"2016-Present Datadog, Inc".
+go.sum,github.com/DataDog/datadog-go,Apache-2.0,"2016-Present Datadog, Inc."
 go.sum,github.com/davecgh/go-spew,ISC,2012-2016 Dave Collins <dave@davec.name>
 go.sum,github.com/dnaeon/go-vcr,BSD-2-Clause,2015-2016 Marin Atanasov Nikolov <dnaeon@gmail.com>
 go.sum,github.com/go-bdd/assert,MIT, 2020 GoBDD
@@ -41,8 +41,8 @@ go.sum,golang.org/x/tools,BSD-3-Clause,2019 The Go Authors
 go.sum,golang.org/x/xerrors,BSD-3-Clause,2019 The Go Authors
 go.sum,google.golang.org/appengine,Apache-2.0,Google Inc.
 go.sum,gopkg.in/check.v1,BSD-2-Clause,2010-2013 Gustavo Niemeyer <gustavo@niemeyer.net>
-go.sum,gopkg.in/DataDog/dd-trace-go.v1,Apache-2.0,"2016-Present Datadog, Inc".
-go.sum,github.com/DataDog/dd-trace-go,Apache-2.0,"2016-Present Datadog, Inc".
+go.sum,gopkg.in/DataDog/dd-trace-go.v1,Apache-2.0,"2016-Present Datadog, Inc."
+go.sum,github.com/DataDog/dd-trace-go,Apache-2.0,"2016-Present Datadog, Inc."
 go.sum,gopkg.in/h2non/gock.v1,MIT,2016-2019 Tomas Aparicio
 go.sum,gopkg.in/yaml.v2,Apache-2.0,2011-2016 Canonical Ltd.
 go.sum,gotest.tools,Apache-2.0,2018 gotest.tools authors


### PR DESCRIPTION
### What does this PR do?

Add quotes to the Datadog copyright lines to escape the `,`. Previously Github couldn't render this file as a table due to the `,` in the copyright line causing this to be seen as an extra column. 

This ensures the file is rendered properly - https://github.com/DataDog/datadog-api-client-go/blob/nick/3rd_csv/LICENSE-3rdparty.csv

### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
