### PR TITLE
Add hasExtendedTitle to security monitoring rule

### DIFF
--- a/api/v2/datadog/api/openapi.yaml
+++ b/api/v2/datadog/api/openapi.yaml
@@ -10032,6 +10032,7 @@ components:
           isDefault: true
           isDeleted: true
           isEnabled: true
+          hasExtendedTitle: true
           name: name
           options:
             newValueOptions: {}
@@ -10079,6 +10080,7 @@ components:
           isDefault: true
           isDeleted: true
           isEnabled: true
+          hasExtendedTitle: true
           name: name
           options:
             newValueOptions: {}
@@ -10149,6 +10151,7 @@ components:
       example:
         cases: []
         isEnabled: true
+        hasExtendedTitle: true
         name: ""
         options:
           newValueOptions: {}
@@ -10175,6 +10178,10 @@ components:
           type: array
         isEnabled:
           description: Whether the rule is enabled.
+          example: true
+          type: boolean
+        hasExtendedTitle:
+          description: Whether the rule has a title extended by group by values.
           example: true
           type: boolean
         message:
@@ -10492,6 +10499,7 @@ components:
         isDefault: true
         isDeleted: true
         isEnabled: true
+        hasExtendedTitle: true
         name: name
         options:
           newValueOptions: {}
@@ -10527,6 +10535,9 @@ components:
           type: boolean
         isEnabled:
           description: Whether the rule is enabled.
+          type: boolean
+        hasExtendedTitle:
+          description: Whether the rule has a title extended by its group by field.
           type: boolean
         message:
           description: Message for generated signals.
@@ -10581,6 +10592,7 @@ components:
           - notifications
           - notifications
         isEnabled: true
+        hasExtendedTitle: true
         name: name
         options:
           newValueOptions: {}
@@ -10624,6 +10636,10 @@ components:
           type: array
         isEnabled:
           description: Whether the rule is enabled.
+          type: boolean
+        hasExtendedTitle:
+          description: Whether the rule has an extended title based on its group by
+            field.
           type: boolean
         message:
           description: Message for generated signals.


### PR DESCRIPTION
### What does this PR do?

Proposed solution for: https://github.com/DataDog/datadog-api-client-go/issues/740

In interacting with the security monitoring API rules, the `hasExtendedTitle` field is not supported by this client implementation yet. Subsequently, we can't use the DataDog Terraform provider for security monitoring rules yet, since this is something we rely on to make our alerting more meaningful.

I'm not sure these changes fully capture what's required for this client API to work correctly, so I'm hoping one of you

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist
Please check relevant items below:
- [X] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.
- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [X] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
