### PR TITLE
tests: add spans for BDD scenarios and recover panics for rerecording

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -58,3 +58,4 @@ go.sum,github.com/Microsoft/go-winio,MIT,2015 Microsoft
 go.sum,github.com/konsorten/go-windows-terminal-sequences,MIT,2017 marvin + konsorten GmbH
 go.sum,github.com/sirupsen/logrus,MIT,2014 Simon Eskildsen
 go.sum,github.com/zippolyte/go-lookup,MIT,2015 Máximo Cuadros
+go.sum,github.com/DataDog/gostackparse,Apache-2.0 OR BSD-3-Clause,"2021 Datadog, Inc."

--- a/go.mod
+++ b/go.mod
@@ -14,11 +14,11 @@ require (
 	golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f // indirect
-	gopkg.in/DataDog/dd-trace-go.v1 v1.29.0-rc.1.0.20210226170446-a8dc39ec3484
+	gopkg.in/DataDog/dd-trace-go.v1 v1.30.0-rc.1.0.20210420124628-f63633f38e8f
 	gopkg.in/h2non/gock.v1 v1.0.15
 	gotest.tools v2.2.0+incompatible
 )
 
-replace gopkg.in/DataDog/dd-trace-go.v1 => github.com/DataDog/dd-trace-go v1.29.0-rc.1.0.20210226170446-a8dc39ec3484
+replace gopkg.in/DataDog/dd-trace-go.v1 => github.com/DataDog/dd-trace-go v1.30.0-rc.1.0.20210420124628-f63633f38e8f
 
 replace github.com/mcuadros/go-lookup => github.com/zippolyte/go-lookup v0.0.0-20210331103309-2b027b989715

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,9 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/DataDog/datadog-go v4.4.0+incompatible h1:R7WqXWP4fIOAqWJtUKmSfuc7eDsBT58k9AY5WSHVosk=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/DataDog/dd-trace-go v1.29.0-rc.1.0.20210226170446-a8dc39ec3484 h1:iyK/ZV0RyPdSVdC+Yxv72RRybHO/GLVHJsGaRnBYXSo=
-github.com/DataDog/dd-trace-go v1.29.0-rc.1.0.20210226170446-a8dc39ec3484/go.mod h1:H9vSLD4Qlnl3rH2fUT6jyP9qwq1lDo0ikaDqSJo8t/U=
+github.com/DataDog/dd-trace-go v1.30.0-rc.1.0.20210420124628-f63633f38e8f h1:J+DQ9rANbV/QEnoDumLth4p5mMUDB28J8ej2CKbcvRs=
+github.com/DataDog/dd-trace-go v1.30.0-rc.1.0.20210420124628-f63633f38e8f/go.mod h1:I3nUNop4UZaHSj2C2OBCHezmsQIHczbUps8nHgw/HXs=
+github.com/DataDog/gostackparse v0.5.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/aslakhellesoy/gox v1.0.100/go.mod h1:AJl542QsKKG96COVsv0N74HHzVQgDIQPceVUh1aeU2M=

--- a/tests/api/v2/datadog/scenarios_test.go
+++ b/tests/api/v2/datadog/scenarios_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"reflect"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/api/v2/datadog"
 	"github.com/DataDog/datadog-api-client-go/tests"
 	"github.com/go-bdd/gobdd"
+	ddtesting "gopkg.in/DataDog/dd-trace-go.v1/contrib/testing"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -30,18 +32,32 @@ func TestScenarios(t *testing.T) {
 		gobdd.WithIgnoredTags(tests.GetIgnoredTags()),
 		gobdd.WithBeforeScenario(func(ctx gobdd.Context) {
 			ct, _ := ctx.Get(gobdd.TestingTKey{})
-			cctx, finish := WithRecorder(
+			tt := ct.(*testing.T)
+			testParts := strings.Split(tt.Name(), "/")
+			cctx, closeSpan := ddtesting.StartSpanWithFinish(
+				NewDefaultContext(context.Background()),
+				tt,
+				ddtesting.WithSpanOptions(
+					tracer.Tag(ext.TestName, testParts[2]),
+					tracer.Tag(ext.TestSuite, fmt.Sprintf("v2/%s", testParts[1])),
+					tracer.Tag(ext.TestFramework, "github.com/go-bdd/gobdd"),
+				),
+			)
+			cctx, closeRecorder := WithRecorder(
 				context.WithValue(
-					NewDefaultContext(context.Background()),
+					cctx,
 					datadog.ContextAPIKeys,
 					map[string]datadog.APIKey{},
 				),
-				ct.(*testing.T),
+				tt,
 			)
 			tests.SetCtx(ctx, cctx)
 			tests.SetRequestsUndo(ctx, requestsUndo)
 			tests.SetData(ctx, make(map[string]interface{}))
-			tests.SetCleanup(ctx, map[string]func(){"99-finish": finish})
+			tests.SetCleanup(ctx, map[string]func(){"99-finish": func() {
+				closeRecorder()
+				closeSpan()
+			}})
 		}), gobdd.WithAfterScenario(func(ctx gobdd.Context) {
 			tests.RunCleanup(ctx)
 		}),

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -250,7 +250,7 @@ func WithTestSpan(ctx context.Context, t *testing.T) (context.Context, func()) {
 		t.Log(err.Error())
 		tag = "features"
 	}
-	return ddtesting.StartSpanWithFinish(ctx, t, ddtesting.WithSkipFrames(2), ddtesting.WithSpanOptions(
+	ctx, finish := ddtesting.StartSpanWithFinish(ctx, t, ddtesting.WithSkipFrames(2), ddtesting.WithSpanOptions(
 		// We need to make the tag be something that is then searchable in monitors
 		// https://docs.datadoghq.com/tracing/guide/metrics_namespace/#errors
 		// "version" is really the only one we can use here
@@ -258,6 +258,13 @@ func WithTestSpan(ctx context.Context, t *testing.T) (context.Context, func()) {
 		// if we set it in StartSpanFromContext, it would get overwritten
 		tracer.Tag(ext.Version, tag),
 	))
+
+	return ctx, func() {
+		if r := recover(); r != nil {
+			t.Errorf("test paniced: %v", r)
+		}
+		finish()
+	}
 }
 
 func createWithDir(path string) (*os.File, error) {


### PR DESCRIPTION
- add test spans for BDD scenarios
- recovers panics in legacy tests