### PR TITLE
Bump go versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.15.x]
+        go-version: [1.14.x, 1.16.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci/skip') && !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')


### PR DESCRIPTION
We're documenting 1.14 as minimal today, so let's test that instead of
1.13. Also start testing 1.16.