### PR TITLE
Speed up check examples

### DIFF
--- a/check-examples.sh
+++ b/check-examples.sh
@@ -13,7 +13,7 @@ for f in examples/$1/*/*.go ; do
     mv $f $df/main.go
 done
 
-ls examples/$1/*/*/main.go | xargs -P $(($(nproc)*2)) -n 1 go build -o /dev/null
+ls -d ./examples/$1/*/* | xargs go build -o /dev/null -ldflags "-s -w"
 if [ $? -ne 0 ]; then
     echo -e "Failed to build examples"
     exit 1


### PR DESCRIPTION
We can have a single call to `go build` if we pass the directories
instead of the go files. This adds also some linker flags that speed
things up a bit.

Before:

  $ time ./check-examples.sh v1
  real	2m53.774s

After:
  $ time ./check-examples.sh v1
  real	0m17.368s