### PR TITLE
Add metric-slo alert to monitor type enum

### DIFF
--- a/api/v1/datadog/api/openapi.yaml
+++ b/api/v1/datadog/api/openapi.yaml
@@ -17508,6 +17508,7 @@ components:
       - slo alert
       - event-v2 alert
       - audit alert
+      - metric-slo alert
       example: metric alert
       type: string
       x-enum-varnames:
@@ -17524,6 +17525,7 @@ components:
       - SLO_ALERT
       - EVENT_V2_ALERT
       - AUDIT_ALERT
+      - METRIC_SLO_ALERT
     MonitorUpdateRequest:
       description: Object describing a monitor update request.
       example:


### PR DESCRIPTION
We are seeing errors in the java sdk for this particular monitor type: 
```
ProcessingException
Error reading entity from input stream.
Cannot construct instance of `com.datadog.api.v1.client.model.MonitorType`, problem: Unexpected value 'metric-slo alert'
```

Is this the same openapi spec used to generate the java sdk?

<!--
** Requirements for Contributing to this repository **

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely 
manner may be closed at the maintainers' discretion.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. 
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." 
If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
