### PR TITLE
Support error-tracking alert

### DIFF
--- a/.generator/schemas/v1/openapi.yaml
+++ b/.generator/schemas/v1/openapi.yaml
@@ -6490,6 +6490,7 @@ components:
       - event-v2 alert
       - audit alert
       - ci-pipelines alert
+      - error-tracking alert
       example: query alert
       type: string
       x-enum-varnames:
@@ -6507,6 +6508,7 @@ components:
       - EVENT_V2_ALERT
       - AUDIT_ALERT
       - CI_PIPELINES_ALERT
+      - ERROR_TRACKING_ALERT
     MonitorUpdateRequest:
       description: Object describing a monitor update request.
       properties:

--- a/api/v1/datadog/docs/MonitorType.md
+++ b/api/v1/datadog/docs/MonitorType.md
@@ -30,4 +30,6 @@
 
 - `CI_PIPELINES_ALERT` (value: `"ci-pipelines alert"`)
 
+- `ERROR_TRACKING_ALERT` (value: `"error-tracking alert"`)
+
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/api/v1/datadog/model_monitor_type.go
+++ b/api/v1/datadog/model_monitor_type.go
@@ -32,6 +32,7 @@ const (
 	MONITORTYPE_EVENT_V2_ALERT        MonitorType = "event-v2 alert"
 	MONITORTYPE_AUDIT_ALERT           MonitorType = "audit alert"
 	MONITORTYPE_CI_PIPELINES_ALERT    MonitorType = "ci-pipelines alert"
+	MONITORTYPE_ERROR_TRACKING_ALERT  MonitorType = "error-tracking alert"
 )
 
 var allowedMonitorTypeEnumValues = []MonitorType{
@@ -49,6 +50,7 @@ var allowedMonitorTypeEnumValues = []MonitorType{
 	"event-v2 alert",
 	"audit alert",
 	"ci-pipelines alert",
+	"error-tracking alert",
 }
 
 func (w *MonitorType) GetAllowedValues() []MonitorType {


### PR DESCRIPTION
### What does this PR do?

Allows parsing of error-tracking alerts.
This PR is to correct the following error that occurs when imputing error-tracking alerts in terraform-provider-datadog.

```
$ terraform import datadog_monitor.my_monitor 123456789
│ Error: object contains unparsed element: map[created:2022-03-14T03:14:44.712215+00:00 created_at:1.647227684e+12 creator:map[email:xxx@xxx handle:xxx@xxx id:xxx name:genki SUGAWARA] deleted:<nil> id:xxx message:@xxx modified:2022-03-14T04:33:12.454800+00:00 multi:true name:test {{[@issue.id].name}} options:map[enable_logs_sample:true escalation_message: groupby_simple_monitor:false include_tags:true new_host_delay:300 notify_audit:false notify_no_data:false restriction_query:<nil> silenced:map[] thresholds:map[critical:1]] org_id:xxx overall_state:No Data overall_state_modified:2022-03-14T03:18:48+00:00 priority:<nil> query:error-tracking-traces("env:staging @issue.age:<=300000").rollup("count").by("@issue.id").last("5m") > 1 restricted_roles:<nil> tags:[] type:error-tracking alert]
```

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [ ] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
