### PR TITLE
Propagate unparsed objects

### DIFF
--- a/.generator/src/generator/cli.py
+++ b/.generator/src/generator/cli.py
@@ -87,7 +87,7 @@ def cli(input, output):
         model_path = output / filename
         model_path.parent.mkdir(parents=True, exist_ok=True)
         with model_path.open("w") as fp:
-            fp.write(model_j2.render(name=name, model=model))
+            fp.write(model_j2.render(name=name, model=model, models=models))
 
     for name, operations in apis.items():
         filename = "api_" + formatter.snake_case(name) + ".go"

--- a/.generator/src/generator/templates/model_simple.j2
+++ b/.generator/src/generator/templates/model_simple.j2
@@ -497,6 +497,16 @@ func (o *{{ name }}) UnmarshalJSON(bytes []byte) (err error) {
 	{%- endfor %}
 	{%- for attr, spec in model.get("properties", {}).items() %}
 	{%- set propertyName = attr|attribute_name %}
+        {%- set dataType = get_type(spec, alternative_name=name + propertyName, render_nullable=True) %}
+        {%- if dataType in models and not spec.enum and not spec.oneOf %}
+        if {% if model|is_reference(attr) %} all.{{ propertyName }} != nil && {% endif %}all.{{ propertyName }}.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+        }
+        {%- endif %}
 	o.{{ propertyName }} = all.{{ propertyName }}
 	{%- endfor %}
 	return nil

--- a/api/v1/datadog/model_alert_graph_widget_definition.go
+++ b/api/v1/datadog/model_alert_graph_widget_definition.go
@@ -341,6 +341,13 @@ func (o *AlertGraphWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.AlertId = all.AlertId
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign

--- a/api/v1/datadog/model_api_key_response.go
+++ b/api/v1/datadog/model_api_key_response.go
@@ -97,6 +97,13 @@ func (o *ApiKeyResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.ApiKey != nil && all.ApiKey.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApiKey = all.ApiKey
 	return nil
 }

--- a/api/v1/datadog/model_application_key_response.go
+++ b/api/v1/datadog/model_application_key_response.go
@@ -97,6 +97,13 @@ func (o *ApplicationKeyResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.ApplicationKey != nil && all.ApplicationKey.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApplicationKey = all.ApplicationKey
 	return nil
 }

--- a/api/v1/datadog/model_change_widget_definition.go
+++ b/api/v1/datadog/model_change_widget_definition.go
@@ -343,6 +343,13 @@ func (o *ChangeWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.CustomLinks = all.CustomLinks
 	o.Requests = all.Requests
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign

--- a/api/v1/datadog/model_change_widget_request.go
+++ b/api/v1/datadog/model_change_widget_request.go
@@ -783,22 +783,78 @@ func (o *ChangeWidgetRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.ApmQuery != nil && all.ApmQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApmQuery = all.ApmQuery
 	o.ChangeType = all.ChangeType
 	o.CompareTo = all.CompareTo
+	if all.EventQuery != nil && all.EventQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.EventQuery = all.EventQuery
 	o.Formulas = all.Formulas
 	o.IncreaseGood = all.IncreaseGood
+	if all.LogQuery != nil && all.LogQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogQuery = all.LogQuery
+	if all.NetworkQuery != nil && all.NetworkQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.NetworkQuery = all.NetworkQuery
 	o.OrderBy = all.OrderBy
 	o.OrderDir = all.OrderDir
+	if all.ProcessQuery != nil && all.ProcessQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProcessQuery = all.ProcessQuery
+	if all.ProfileMetricsQuery != nil && all.ProfileMetricsQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProfileMetricsQuery = all.ProfileMetricsQuery
 	o.Q = all.Q
 	o.Queries = all.Queries
 	o.ResponseFormat = all.ResponseFormat
+	if all.RumQuery != nil && all.RumQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.RumQuery = all.RumQuery
+	if all.SecurityQuery != nil && all.SecurityQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SecurityQuery = all.SecurityQuery
 	o.ShowPresent = all.ShowPresent
 	return nil

--- a/api/v1/datadog/model_check_can_delete_monitor_response.go
+++ b/api/v1/datadog/model_check_can_delete_monitor_response.go
@@ -136,6 +136,13 @@ func (o *CheckCanDeleteMonitorResponse) UnmarshalJSON(bytes []byte) (err error) 
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	o.Errors = all.Errors
 	return nil

--- a/api/v1/datadog/model_check_can_delete_slo_response.go
+++ b/api/v1/datadog/model_check_can_delete_slo_response.go
@@ -135,6 +135,13 @@ func (o *CheckCanDeleteSLOResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	o.Errors = all.Errors
 	return nil

--- a/api/v1/datadog/model_check_status_widget_definition.go
+++ b/api/v1/datadog/model_check_status_widget_definition.go
@@ -459,6 +459,13 @@ func (o *CheckStatusWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 	o.GroupBy = all.GroupBy
 	o.Grouping = all.Grouping
 	o.Tags = all.Tags
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign

--- a/api/v1/datadog/model_dashboard_list.go
+++ b/api/v1/datadog/model_dashboard_list.go
@@ -365,6 +365,13 @@ func (o *DashboardList) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Author != nil && all.Author.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Author = all.Author
 	o.Created = all.Created
 	o.DashboardCount = all.DashboardCount

--- a/api/v1/datadog/model_distribution_widget_definition.go
+++ b/api/v1/datadog/model_distribution_widget_definition.go
@@ -507,12 +507,33 @@ func (o *DistributionWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 	o.Markers = all.Markers
 	o.Requests = all.Requests
 	o.ShowLegend = all.ShowLegend
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign
 	o.TitleSize = all.TitleSize
 	o.Type = all.Type
+	if all.Xaxis != nil && all.Xaxis.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Xaxis = all.Xaxis
+	if all.Yaxis != nil && all.Yaxis.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Yaxis = all.Yaxis
 	return nil
 }

--- a/api/v1/datadog/model_distribution_widget_request.go
+++ b/api/v1/datadog/model_distribution_widget_request.go
@@ -477,16 +477,86 @@ func (o *DistributionWidgetRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.ApmQuery != nil && all.ApmQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApmQuery = all.ApmQuery
+	if all.ApmStatsQuery != nil && all.ApmStatsQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApmStatsQuery = all.ApmStatsQuery
+	if all.EventQuery != nil && all.EventQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.EventQuery = all.EventQuery
+	if all.LogQuery != nil && all.LogQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogQuery = all.LogQuery
+	if all.NetworkQuery != nil && all.NetworkQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.NetworkQuery = all.NetworkQuery
+	if all.ProcessQuery != nil && all.ProcessQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProcessQuery = all.ProcessQuery
+	if all.ProfileMetricsQuery != nil && all.ProfileMetricsQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProfileMetricsQuery = all.ProfileMetricsQuery
 	o.Q = all.Q
+	if all.RumQuery != nil && all.RumQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.RumQuery = all.RumQuery
+	if all.SecurityQuery != nil && all.SecurityQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SecurityQuery = all.SecurityQuery
+	if all.Style != nil && all.Style.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Style = all.Style
 	return nil
 }

--- a/api/v1/datadog/model_event_create_response.go
+++ b/api/v1/datadog/model_event_create_response.go
@@ -135,6 +135,13 @@ func (o *EventCreateResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Event != nil && all.Event.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Event = all.Event
 	o.Status = all.Status
 	return nil

--- a/api/v1/datadog/model_event_response.go
+++ b/api/v1/datadog/model_event_response.go
@@ -135,6 +135,13 @@ func (o *EventResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Event != nil && all.Event.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Event = all.Event
 	o.Status = all.Status
 	return nil

--- a/api/v1/datadog/model_event_stream_widget_definition.go
+++ b/api/v1/datadog/model_event_stream_widget_definition.go
@@ -388,6 +388,13 @@ func (o *EventStreamWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 	o.EventSize = all.EventSize
 	o.Query = all.Query
 	o.TagsExecution = all.TagsExecution
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign

--- a/api/v1/datadog/model_event_timeline_widget_definition.go
+++ b/api/v1/datadog/model_event_timeline_widget_definition.go
@@ -340,6 +340,13 @@ func (o *EventTimelineWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) 
 	}
 	o.Query = all.Query
 	o.TagsExecution = all.TagsExecution
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign

--- a/api/v1/datadog/model_formula_and_function_event_query_definition.go
+++ b/api/v1/datadog/model_formula_and_function_event_query_definition.go
@@ -284,11 +284,25 @@ func (o *FormulaAndFunctionEventQueryDefinition) UnmarshalJSON(bytes []byte) (er
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Compute.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Compute = all.Compute
 	o.DataSource = all.DataSource
 	o.GroupBy = all.GroupBy
 	o.Indexes = all.Indexes
 	o.Name = all.Name
+	if all.Search != nil && all.Search.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Search = all.Search
 	return nil
 }

--- a/api/v1/datadog/model_formula_and_function_event_query_group_by.go
+++ b/api/v1/datadog/model_formula_and_function_event_query_group_by.go
@@ -176,6 +176,13 @@ func (o *FormulaAndFunctionEventQueryGroupBy) UnmarshalJSON(bytes []byte) (err e
 	}
 	o.Facet = all.Facet
 	o.Limit = all.Limit
+	if all.Sort != nil && all.Sort.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Sort = all.Sort
 	return nil
 }

--- a/api/v1/datadog/model_funnel_widget_definition.go
+++ b/api/v1/datadog/model_funnel_widget_definition.go
@@ -302,6 +302,13 @@ func (o *FunnelWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Requests = all.Requests
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign

--- a/api/v1/datadog/model_funnel_widget_request.go
+++ b/api/v1/datadog/model_funnel_widget_request.go
@@ -138,6 +138,13 @@ func (o *FunnelWidgetRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Query.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Query = all.Query
 	o.RequestType = all.RequestType
 	return nil

--- a/api/v1/datadog/model_geomap_widget_definition.go
+++ b/api/v1/datadog/model_geomap_widget_definition.go
@@ -407,12 +407,33 @@ func (o *GeomapWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.CustomLinks = all.CustomLinks
 	o.Requests = all.Requests
+	if all.Style.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Style = all.Style
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign
 	o.TitleSize = all.TitleSize
 	o.Type = all.Type
+	if all.View.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.View = all.View
 	return nil
 }

--- a/api/v1/datadog/model_geomap_widget_request.go
+++ b/api/v1/datadog/model_geomap_widget_request.go
@@ -334,11 +334,32 @@ func (o *GeomapWidgetRequest) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Formulas = all.Formulas
+	if all.LogQuery != nil && all.LogQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogQuery = all.LogQuery
 	o.Q = all.Q
 	o.Queries = all.Queries
 	o.ResponseFormat = all.ResponseFormat
+	if all.RumQuery != nil && all.RumQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.RumQuery = all.RumQuery
+	if all.SecurityQuery != nil && all.SecurityQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SecurityQuery = all.SecurityQuery
 	return nil
 }

--- a/api/v1/datadog/model_heat_map_widget_definition.go
+++ b/api/v1/datadog/model_heat_map_widget_definition.go
@@ -495,11 +495,25 @@ func (o *HeatMapWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 	o.LegendSize = all.LegendSize
 	o.Requests = all.Requests
 	o.ShowLegend = all.ShowLegend
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign
 	o.TitleSize = all.TitleSize
 	o.Type = all.Type
+	if all.Yaxis != nil && all.Yaxis.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Yaxis = all.Yaxis
 	return nil
 }

--- a/api/v1/datadog/model_heat_map_widget_request.go
+++ b/api/v1/datadog/model_heat_map_widget_request.go
@@ -439,15 +439,78 @@ func (o *HeatMapWidgetRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.ApmQuery != nil && all.ApmQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApmQuery = all.ApmQuery
+	if all.EventQuery != nil && all.EventQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.EventQuery = all.EventQuery
+	if all.LogQuery != nil && all.LogQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogQuery = all.LogQuery
+	if all.NetworkQuery != nil && all.NetworkQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.NetworkQuery = all.NetworkQuery
+	if all.ProcessQuery != nil && all.ProcessQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProcessQuery = all.ProcessQuery
+	if all.ProfileMetricsQuery != nil && all.ProfileMetricsQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProfileMetricsQuery = all.ProfileMetricsQuery
 	o.Q = all.Q
+	if all.RumQuery != nil && all.RumQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.RumQuery = all.RumQuery
+	if all.SecurityQuery != nil && all.SecurityQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SecurityQuery = all.SecurityQuery
+	if all.Style != nil && all.Style.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Style = all.Style
 	return nil
 }

--- a/api/v1/datadog/model_host.go
+++ b/api/v1/datadog/model_host.go
@@ -598,7 +598,21 @@ func (o *Host) UnmarshalJSON(bytes []byte) (err error) {
 	o.Id = all.Id
 	o.IsMuted = all.IsMuted
 	o.LastReportedTime = all.LastReportedTime
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
+	if all.Metrics != nil && all.Metrics.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Metrics = all.Metrics
 	o.MuteTimeout = all.MuteTimeout
 	o.Name = all.Name

--- a/api/v1/datadog/model_host_map_request.go
+++ b/api/v1/datadog/model_host_map_request.go
@@ -401,14 +401,70 @@ func (o *HostMapRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.ApmQuery != nil && all.ApmQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApmQuery = all.ApmQuery
+	if all.EventQuery != nil && all.EventQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.EventQuery = all.EventQuery
+	if all.LogQuery != nil && all.LogQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogQuery = all.LogQuery
+	if all.NetworkQuery != nil && all.NetworkQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.NetworkQuery = all.NetworkQuery
+	if all.ProcessQuery != nil && all.ProcessQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProcessQuery = all.ProcessQuery
+	if all.ProfileMetricsQuery != nil && all.ProfileMetricsQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProfileMetricsQuery = all.ProfileMetricsQuery
 	o.Q = all.Q
+	if all.RumQuery != nil && all.RumQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.RumQuery = all.RumQuery
+	if all.SecurityQuery != nil && all.SecurityQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SecurityQuery = all.SecurityQuery
 	return nil
 }

--- a/api/v1/datadog/model_host_map_widget_definition.go
+++ b/api/v1/datadog/model_host_map_widget_definition.go
@@ -580,8 +580,22 @@ func (o *HostMapWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 	o.NoMetricHosts = all.NoMetricHosts
 	o.NodeType = all.NodeType
 	o.Notes = all.Notes
+	if all.Requests.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Requests = all.Requests
 	o.Scope = all.Scope
+	if all.Style != nil && all.Style.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Style = all.Style
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign

--- a/api/v1/datadog/model_host_map_widget_definition_requests.go
+++ b/api/v1/datadog/model_host_map_widget_definition_requests.go
@@ -135,7 +135,21 @@ func (o *HostMapWidgetDefinitionRequests) UnmarshalJSON(bytes []byte) (err error
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Fill != nil && all.Fill.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Fill = all.Fill
+	if all.Size != nil && all.Size.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Size = all.Size
 	return nil
 }

--- a/api/v1/datadog/model_host_meta.go
+++ b/api/v1/datadog/model_host_meta.go
@@ -634,6 +634,13 @@ func (o *HostMeta) UnmarshalJSON(bytes []byte) (err error) {
 	o.CpuCores = all.CpuCores
 	o.FbsdV = all.FbsdV
 	o.Gohai = all.Gohai
+	if all.InstallMethod != nil && all.InstallMethod.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.InstallMethod = all.InstallMethod
 	o.MacV = all.MacV
 	o.Machine = all.Machine

--- a/api/v1/datadog/model_hourly_usage_attribution_metadata.go
+++ b/api/v1/datadog/model_hourly_usage_attribution_metadata.go
@@ -97,6 +97,13 @@ func (o *HourlyUsageAttributionMetadata) UnmarshalJSON(bytes []byte) (err error)
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Pagination != nil && all.Pagination.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Pagination = all.Pagination
 	return nil
 }

--- a/api/v1/datadog/model_hourly_usage_attribution_response.go
+++ b/api/v1/datadog/model_hourly_usage_attribution_response.go
@@ -135,6 +135,13 @@ func (o *HourlyUsageAttributionResponse) UnmarshalJSON(bytes []byte) (err error)
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Metadata != nil && all.Metadata.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Metadata = all.Metadata
 	o.Usage = all.Usage
 	return nil

--- a/api/v1/datadog/model_ip_ranges.go
+++ b/api/v1/datadog/model_ip_ranges.go
@@ -401,14 +401,63 @@ func (o *IPRanges) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Agents != nil && all.Agents.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Agents = all.Agents
+	if all.Api != nil && all.Api.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Api = all.Api
+	if all.Apm != nil && all.Apm.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Apm = all.Apm
+	if all.Logs != nil && all.Logs.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Logs = all.Logs
 	o.Modified = all.Modified
+	if all.Process != nil && all.Process.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Process = all.Process
+	if all.Synthetics != nil && all.Synthetics.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Synthetics = all.Synthetics
 	o.Version = all.Version
+	if all.Webhooks != nil && all.Webhooks.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Webhooks = all.Webhooks
 	return nil
 }

--- a/api/v1/datadog/model_list_stream_widget_definition.go
+++ b/api/v1/datadog/model_list_stream_widget_definition.go
@@ -381,6 +381,13 @@ func (o *ListStreamWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 	o.LegendSize = all.LegendSize
 	o.Requests = all.Requests
 	o.ShowLegend = all.ShowLegend
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign

--- a/api/v1/datadog/model_list_stream_widget_request.go
+++ b/api/v1/datadog/model_list_stream_widget_request.go
@@ -171,6 +171,13 @@ func (o *ListStreamWidgetRequest) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Columns = all.Columns
+	if all.Query.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Query = all.Query
 	o.ResponseFormat = all.ResponseFormat
 	return nil

--- a/api/v1/datadog/model_log.go
+++ b/api/v1/datadog/model_log.go
@@ -135,6 +135,13 @@ func (o *Log) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Content != nil && all.Content.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Content = all.Content
 	o.Id = all.Id
 	return nil

--- a/api/v1/datadog/model_log_query_definition.go
+++ b/api/v1/datadog/model_log_query_definition.go
@@ -249,10 +249,24 @@ func (o *LogQueryDefinition) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Compute != nil && all.Compute.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Compute = all.Compute
 	o.GroupBy = all.GroupBy
 	o.Index = all.Index
 	o.MultiCompute = all.MultiCompute
+	if all.Search != nil && all.Search.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Search = all.Search
 	return nil
 }

--- a/api/v1/datadog/model_log_query_definition_group_by.go
+++ b/api/v1/datadog/model_log_query_definition_group_by.go
@@ -176,6 +176,13 @@ func (o *LogQueryDefinitionGroupBy) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.Facet = all.Facet
 	o.Limit = all.Limit
+	if all.Sort != nil && all.Sort.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Sort = all.Sort
 	return nil
 }

--- a/api/v1/datadog/model_log_stream_widget_definition.go
+++ b/api/v1/datadog/model_log_stream_widget_definition.go
@@ -591,7 +591,21 @@ func (o *LogStreamWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 	o.Query = all.Query
 	o.ShowDateColumn = all.ShowDateColumn
 	o.ShowMessageColumn = all.ShowMessageColumn
+	if all.Sort != nil && all.Sort.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Sort = all.Sort
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign

--- a/api/v1/datadog/model_logs_api_error_response.go
+++ b/api/v1/datadog/model_logs_api_error_response.go
@@ -97,6 +97,13 @@ func (o *LogsAPIErrorResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Error != nil && all.Error.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Error = all.Error
 	return nil
 }

--- a/api/v1/datadog/model_logs_by_retention.go
+++ b/api/v1/datadog/model_logs_by_retention.go
@@ -173,8 +173,22 @@ func (o *LogsByRetention) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Orgs != nil && all.Orgs.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Orgs = all.Orgs
 	o.Usage = all.Usage
+	if all.UsageByMonth != nil && all.UsageByMonth.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.UsageByMonth = all.UsageByMonth
 	return nil
 }

--- a/api/v1/datadog/model_logs_category_processor_category.go
+++ b/api/v1/datadog/model_logs_category_processor_category.go
@@ -135,6 +135,13 @@ func (o *LogsCategoryProcessorCategory) UnmarshalJSON(bytes []byte) (err error) 
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Filter != nil && all.Filter.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Filter = all.Filter
 	o.Name = all.Name
 	return nil

--- a/api/v1/datadog/model_logs_exclusion.go
+++ b/api/v1/datadog/model_logs_exclusion.go
@@ -174,6 +174,13 @@ func (o *LogsExclusion) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Filter != nil && all.Filter.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Filter = all.Filter
 	o.IsEnabled = all.IsEnabled
 	o.Name = all.Name

--- a/api/v1/datadog/model_logs_grok_parser.go
+++ b/api/v1/datadog/model_logs_grok_parser.go
@@ -293,6 +293,13 @@ func (o *LogsGrokParser) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Grok.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Grok = all.Grok
 	o.IsEnabled = all.IsEnabled
 	o.Name = all.Name

--- a/api/v1/datadog/model_logs_index.go
+++ b/api/v1/datadog/model_logs_index.go
@@ -288,6 +288,13 @@ func (o *LogsIndex) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.DailyLimit = all.DailyLimit
 	o.ExclusionFilters = all.ExclusionFilters
+	if all.Filter.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Filter = all.Filter
 	o.IsRateLimited = all.IsRateLimited
 	o.Name = all.Name

--- a/api/v1/datadog/model_logs_index_update_request.go
+++ b/api/v1/datadog/model_logs_index_update_request.go
@@ -261,6 +261,13 @@ func (o *LogsIndexUpdateRequest) UnmarshalJSON(bytes []byte) (err error) {
 	o.DailyLimit = all.DailyLimit
 	o.DisableDailyLimit = all.DisableDailyLimit
 	o.ExclusionFilters = all.ExclusionFilters
+	if all.Filter.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Filter = all.Filter
 	o.NumRetentionDays = all.NumRetentionDays
 	return nil

--- a/api/v1/datadog/model_logs_list_request.go
+++ b/api/v1/datadog/model_logs_list_request.go
@@ -306,6 +306,13 @@ func (o *LogsListRequest) UnmarshalJSON(bytes []byte) (err error) {
 	o.Query = all.Query
 	o.Sort = all.Sort
 	o.StartAt = all.StartAt
+	if all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	return nil
 }

--- a/api/v1/datadog/model_logs_pipeline.go
+++ b/api/v1/datadog/model_logs_pipeline.go
@@ -330,6 +330,13 @@ func (o *LogsPipeline) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Filter != nil && all.Filter.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Filter = all.Filter
 	o.Id = all.Id
 	o.IsEnabled = all.IsEnabled

--- a/api/v1/datadog/model_logs_pipeline_processor.go
+++ b/api/v1/datadog/model_logs_pipeline_processor.go
@@ -268,6 +268,13 @@ func (o *LogsPipelineProcessor) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Filter != nil && all.Filter.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Filter = all.Filter
 	o.IsEnabled = all.IsEnabled
 	o.Name = all.Name

--- a/api/v1/datadog/model_metric_search_response.go
+++ b/api/v1/datadog/model_metric_search_response.go
@@ -97,6 +97,13 @@ func (o *MetricSearchResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Results != nil && all.Results.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Results = all.Results
 	return nil
 }

--- a/api/v1/datadog/model_monitor.go
+++ b/api/v1/datadog/model_monitor.go
@@ -703,6 +703,13 @@ func (o *Monitor) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Created = all.Created
+	if all.Creator != nil && all.Creator.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Creator = all.Creator
 	o.Deleted = all.Deleted
 	o.Id = all.Id
@@ -710,11 +717,25 @@ func (o *Monitor) UnmarshalJSON(bytes []byte) (err error) {
 	o.Modified = all.Modified
 	o.Multi = all.Multi
 	o.Name = all.Name
+	if all.Options != nil && all.Options.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Options = all.Options
 	o.OverallState = all.OverallState
 	o.Priority = all.Priority
 	o.Query = all.Query
 	o.RestrictedRoles = all.RestrictedRoles
+	if all.State != nil && all.State.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.State = all.State
 	o.Tags = all.Tags
 	o.Type = all.Type

--- a/api/v1/datadog/model_monitor_formula_and_function_event_query_definition.go
+++ b/api/v1/datadog/model_monitor_formula_and_function_event_query_definition.go
@@ -284,11 +284,25 @@ func (o *MonitorFormulaAndFunctionEventQueryDefinition) UnmarshalJSON(bytes []by
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Compute.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Compute = all.Compute
 	o.DataSource = all.DataSource
 	o.GroupBy = all.GroupBy
 	o.Indexes = all.Indexes
 	o.Name = all.Name
+	if all.Search != nil && all.Search.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Search = all.Search
 	return nil
 }

--- a/api/v1/datadog/model_monitor_formula_and_function_event_query_group_by.go
+++ b/api/v1/datadog/model_monitor_formula_and_function_event_query_group_by.go
@@ -176,6 +176,13 @@ func (o *MonitorFormulaAndFunctionEventQueryGroupBy) UnmarshalJSON(bytes []byte)
 	}
 	o.Facet = all.Facet
 	o.Limit = all.Limit
+	if all.Sort != nil && all.Sort.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Sort = all.Sort
 	return nil
 }

--- a/api/v1/datadog/model_monitor_group_search_response.go
+++ b/api/v1/datadog/model_monitor_group_search_response.go
@@ -173,8 +173,22 @@ func (o *MonitorGroupSearchResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Counts != nil && all.Counts.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Counts = all.Counts
 	o.Groups = all.Groups
+	if all.Metadata != nil && all.Metadata.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Metadata = all.Metadata
 	return nil
 }

--- a/api/v1/datadog/model_monitor_options.go
+++ b/api/v1/datadog/model_monitor_options.go
@@ -1196,6 +1196,13 @@ func (o *MonitorOptions) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Aggregation != nil && all.Aggregation.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Aggregation = all.Aggregation
 	o.DeviceIds = all.DeviceIds
 	o.EnableLogsSample = all.EnableLogsSample
@@ -1217,7 +1224,21 @@ func (o *MonitorOptions) UnmarshalJSON(bytes []byte) (err error) {
 	o.RequireFullWindow = all.RequireFullWindow
 	o.Silenced = all.Silenced
 	o.SyntheticsCheckId = all.SyntheticsCheckId
+	if all.ThresholdWindows != nil && all.ThresholdWindows.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ThresholdWindows = all.ThresholdWindows
+	if all.Thresholds != nil && all.Thresholds.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Thresholds = all.Thresholds
 	o.TimeoutH = all.TimeoutH
 	o.Variables = all.Variables

--- a/api/v1/datadog/model_monitor_search_response.go
+++ b/api/v1/datadog/model_monitor_search_response.go
@@ -173,7 +173,21 @@ func (o *MonitorSearchResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Counts != nil && all.Counts.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Counts = all.Counts
+	if all.Metadata != nil && all.Metadata.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Metadata = all.Metadata
 	o.Monitors = all.Monitors
 	return nil

--- a/api/v1/datadog/model_monitor_search_result.go
+++ b/api/v1/datadog/model_monitor_search_result.go
@@ -584,6 +584,13 @@ func (o *MonitorSearchResult) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Classification = all.Classification
+	if all.Creator != nil && all.Creator.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Creator = all.Creator
 	o.Id = all.Id
 	o.LastTriggeredTs = all.LastTriggeredTs

--- a/api/v1/datadog/model_monitor_update_request.go
+++ b/api/v1/datadog/model_monitor_update_request.go
@@ -696,6 +696,13 @@ func (o *MonitorUpdateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Created = all.Created
+	if all.Creator != nil && all.Creator.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Creator = all.Creator
 	o.Deleted = all.Deleted
 	o.Id = all.Id
@@ -703,11 +710,25 @@ func (o *MonitorUpdateRequest) UnmarshalJSON(bytes []byte) (err error) {
 	o.Modified = all.Modified
 	o.Multi = all.Multi
 	o.Name = all.Name
+	if all.Options != nil && all.Options.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Options = all.Options
 	o.OverallState = all.OverallState
 	o.Priority = all.Priority
 	o.Query = all.Query
 	o.RestrictedRoles = all.RestrictedRoles
+	if all.State != nil && all.State.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.State = all.State
 	o.Tags = all.Tags
 	o.Type = all.Type

--- a/api/v1/datadog/model_monthly_usage_attribution_body.go
+++ b/api/v1/datadog/model_monthly_usage_attribution_body.go
@@ -332,6 +332,13 @@ func (o *MonthlyUsageAttributionBody) UnmarshalJSON(bytes []byte) (err error) {
 	o.TagConfigSource = all.TagConfigSource
 	o.Tags = all.Tags
 	o.UpdatedAt = all.UpdatedAt
+	if all.Values != nil && all.Values.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Values = all.Values
 	return nil
 }

--- a/api/v1/datadog/model_monthly_usage_attribution_metadata.go
+++ b/api/v1/datadog/model_monthly_usage_attribution_metadata.go
@@ -136,6 +136,13 @@ func (o *MonthlyUsageAttributionMetadata) UnmarshalJSON(bytes []byte) (err error
 		return nil
 	}
 	o.Aggregates = all.Aggregates
+	if all.Pagination != nil && all.Pagination.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Pagination = all.Pagination
 	return nil
 }

--- a/api/v1/datadog/model_monthly_usage_attribution_response.go
+++ b/api/v1/datadog/model_monthly_usage_attribution_response.go
@@ -135,6 +135,13 @@ func (o *MonthlyUsageAttributionResponse) UnmarshalJSON(bytes []byte) (err error
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Metadata != nil && all.Metadata.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Metadata = all.Metadata
 	o.Usage = all.Usage
 	return nil

--- a/api/v1/datadog/model_notebook_create_data.go
+++ b/api/v1/datadog/model_notebook_create_data.go
@@ -140,6 +140,13 @@ func (o *NotebookCreateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Type = all.Type
 	return nil

--- a/api/v1/datadog/model_notebook_create_data_attributes.go
+++ b/api/v1/datadog/model_notebook_create_data_attributes.go
@@ -251,6 +251,13 @@ func (o *NotebookCreateDataAttributes) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Cells = all.Cells
+	if all.Metadata != nil && all.Metadata.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Metadata = all.Metadata
 	o.Name = all.Name
 	o.Status = all.Status

--- a/api/v1/datadog/model_notebook_create_request.go
+++ b/api/v1/datadog/model_notebook_create_request.go
@@ -98,6 +98,13 @@ func (o *NotebookCreateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v1/datadog/model_notebook_distribution_cell_attributes.go
+++ b/api/v1/datadog/model_notebook_distribution_cell_attributes.go
@@ -233,8 +233,22 @@ func (o *NotebookDistributionCellAttributes) UnmarshalJSON(bytes []byte) (err er
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Definition.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Definition = all.Definition
 	o.GraphSize = all.GraphSize
+	if all.SplitBy != nil && all.SplitBy.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SplitBy = all.SplitBy
 	o.Time = all.Time
 	return nil

--- a/api/v1/datadog/model_notebook_heat_map_cell_attributes.go
+++ b/api/v1/datadog/model_notebook_heat_map_cell_attributes.go
@@ -231,8 +231,22 @@ func (o *NotebookHeatMapCellAttributes) UnmarshalJSON(bytes []byte) (err error) 
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Definition.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Definition = all.Definition
 	o.GraphSize = all.GraphSize
+	if all.SplitBy != nil && all.SplitBy.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SplitBy = all.SplitBy
 	o.Time = all.Time
 	return nil

--- a/api/v1/datadog/model_notebook_log_stream_cell_attributes.go
+++ b/api/v1/datadog/model_notebook_log_stream_cell_attributes.go
@@ -193,6 +193,13 @@ func (o *NotebookLogStreamCellAttributes) UnmarshalJSON(bytes []byte) (err error
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Definition.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Definition = all.Definition
 	o.GraphSize = all.GraphSize
 	o.Time = all.Time

--- a/api/v1/datadog/model_notebook_markdown_cell_attributes.go
+++ b/api/v1/datadog/model_notebook_markdown_cell_attributes.go
@@ -98,6 +98,13 @@ func (o *NotebookMarkdownCellAttributes) UnmarshalJSON(bytes []byte) (err error)
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Definition.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Definition = all.Definition
 	return nil
 }

--- a/api/v1/datadog/model_notebook_response.go
+++ b/api/v1/datadog/model_notebook_response.go
@@ -97,6 +97,13 @@ func (o *NotebookResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v1/datadog/model_notebook_response_data.go
+++ b/api/v1/datadog/model_notebook_response_data.go
@@ -172,6 +172,13 @@ func (o *NotebookResponseData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v1/datadog/model_notebook_response_data_attributes.go
+++ b/api/v1/datadog/model_notebook_response_data_attributes.go
@@ -365,9 +365,23 @@ func (o *NotebookResponseDataAttributes) UnmarshalJSON(bytes []byte) (err error)
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Author != nil && all.Author.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Author = all.Author
 	o.Cells = all.Cells
 	o.Created = all.Created
+	if all.Metadata != nil && all.Metadata.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Metadata = all.Metadata
 	o.Modified = all.Modified
 	o.Name = all.Name

--- a/api/v1/datadog/model_notebook_timeseries_cell_attributes.go
+++ b/api/v1/datadog/model_notebook_timeseries_cell_attributes.go
@@ -231,8 +231,22 @@ func (o *NotebookTimeseriesCellAttributes) UnmarshalJSON(bytes []byte) (err erro
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Definition.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Definition = all.Definition
 	o.GraphSize = all.GraphSize
+	if all.SplitBy != nil && all.SplitBy.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SplitBy = all.SplitBy
 	o.Time = all.Time
 	return nil

--- a/api/v1/datadog/model_notebook_toplist_cell_attributes.go
+++ b/api/v1/datadog/model_notebook_toplist_cell_attributes.go
@@ -231,8 +231,22 @@ func (o *NotebookToplistCellAttributes) UnmarshalJSON(bytes []byte) (err error) 
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Definition.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Definition = all.Definition
 	o.GraphSize = all.GraphSize
+	if all.SplitBy != nil && all.SplitBy.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SplitBy = all.SplitBy
 	o.Time = all.Time
 	return nil

--- a/api/v1/datadog/model_notebook_update_data.go
+++ b/api/v1/datadog/model_notebook_update_data.go
@@ -140,6 +140,13 @@ func (o *NotebookUpdateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Type = all.Type
 	return nil

--- a/api/v1/datadog/model_notebook_update_data_attributes.go
+++ b/api/v1/datadog/model_notebook_update_data_attributes.go
@@ -251,6 +251,13 @@ func (o *NotebookUpdateDataAttributes) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Cells = all.Cells
+	if all.Metadata != nil && all.Metadata.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Metadata = all.Metadata
 	o.Name = all.Name
 	o.Status = all.Status

--- a/api/v1/datadog/model_notebook_update_request.go
+++ b/api/v1/datadog/model_notebook_update_request.go
@@ -98,6 +98,13 @@ func (o *NotebookUpdateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v1/datadog/model_notebooks_response.go
+++ b/api/v1/datadog/model_notebooks_response.go
@@ -136,6 +136,13 @@ func (o *NotebooksResponse) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Data = all.Data
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v1/datadog/model_notebooks_response_data.go
+++ b/api/v1/datadog/model_notebooks_response_data.go
@@ -172,6 +172,13 @@ func (o *NotebooksResponseData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v1/datadog/model_notebooks_response_data_attributes.go
+++ b/api/v1/datadog/model_notebooks_response_data_attributes.go
@@ -377,9 +377,23 @@ func (o *NotebooksResponseDataAttributes) UnmarshalJSON(bytes []byte) (err error
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Author != nil && all.Author.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Author = all.Author
 	o.Cells = all.Cells
 	o.Created = all.Created
+	if all.Metadata != nil && all.Metadata.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Metadata = all.Metadata
 	o.Modified = all.Modified
 	o.Name = all.Name

--- a/api/v1/datadog/model_notebooks_response_meta.go
+++ b/api/v1/datadog/model_notebooks_response_meta.go
@@ -97,6 +97,13 @@ func (o *NotebooksResponseMeta) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	return nil
 }

--- a/api/v1/datadog/model_organization.go
+++ b/api/v1/datadog/model_organization.go
@@ -333,12 +333,33 @@ func (o *Organization) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Billing != nil && all.Billing.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Billing = all.Billing
 	o.Created = all.Created
 	o.Description = all.Description
 	o.Name = all.Name
 	o.PublicId = all.PublicId
+	if all.Settings != nil && all.Settings.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Settings = all.Settings
+	if all.Subscription != nil && all.Subscription.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Subscription = all.Subscription
 	return nil
 }

--- a/api/v1/datadog/model_organization_create_body.go
+++ b/api/v1/datadog/model_organization_create_body.go
@@ -182,8 +182,22 @@ func (o *OrganizationCreateBody) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Billing != nil && all.Billing.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Billing = all.Billing
 	o.Name = all.Name
+	if all.Subscription != nil && all.Subscription.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Subscription = all.Subscription
 	return nil
 }

--- a/api/v1/datadog/model_organization_create_response.go
+++ b/api/v1/datadog/model_organization_create_response.go
@@ -211,9 +211,37 @@ func (o *OrganizationCreateResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.ApiKey != nil && all.ApiKey.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApiKey = all.ApiKey
+	if all.ApplicationKey != nil && all.ApplicationKey.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApplicationKey = all.ApplicationKey
+	if all.Org != nil && all.Org.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Org = all.Org
+	if all.User != nil && all.User.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.User = all.User
 	return nil
 }

--- a/api/v1/datadog/model_organization_response.go
+++ b/api/v1/datadog/model_organization_response.go
@@ -97,6 +97,13 @@ func (o *OrganizationResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Org != nil && all.Org.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Org = all.Org
 	return nil
 }

--- a/api/v1/datadog/model_organization_settings.go
+++ b/api/v1/datadog/model_organization_settings.go
@@ -453,14 +453,42 @@ func (o *OrganizationSettings) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.PrivateWidgetShare = all.PrivateWidgetShare
+	if all.Saml != nil && all.Saml.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Saml = all.Saml
 	o.SamlAutocreateAccessRole = all.SamlAutocreateAccessRole
+	if all.SamlAutocreateUsersDomains != nil && all.SamlAutocreateUsersDomains.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SamlAutocreateUsersDomains = all.SamlAutocreateUsersDomains
 	o.SamlCanBeEnabled = all.SamlCanBeEnabled
 	o.SamlIdpEndpoint = all.SamlIdpEndpoint
+	if all.SamlIdpInitiatedLogin != nil && all.SamlIdpInitiatedLogin.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SamlIdpInitiatedLogin = all.SamlIdpInitiatedLogin
 	o.SamlIdpMetadataUploaded = all.SamlIdpMetadataUploaded
 	o.SamlLoginUrl = all.SamlLoginUrl
+	if all.SamlStrictMode != nil && all.SamlStrictMode.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SamlStrictMode = all.SamlStrictMode
 	return nil
 }

--- a/api/v1/datadog/model_query_value_widget_definition.go
+++ b/api/v1/datadog/model_query_value_widget_definition.go
@@ -504,6 +504,13 @@ func (o *QueryValueWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 	o.Precision = all.Precision
 	o.Requests = all.Requests
 	o.TextAlign = all.TextAlign
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign

--- a/api/v1/datadog/model_query_value_widget_request.go
+++ b/api/v1/datadog/model_query_value_widget_request.go
@@ -646,19 +646,82 @@ func (o *QueryValueWidgetRequest) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Aggregator = all.Aggregator
+	if all.ApmQuery != nil && all.ApmQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApmQuery = all.ApmQuery
+	if all.AuditQuery != nil && all.AuditQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.AuditQuery = all.AuditQuery
 	o.ConditionalFormats = all.ConditionalFormats
+	if all.EventQuery != nil && all.EventQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.EventQuery = all.EventQuery
 	o.Formulas = all.Formulas
+	if all.LogQuery != nil && all.LogQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogQuery = all.LogQuery
+	if all.NetworkQuery != nil && all.NetworkQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.NetworkQuery = all.NetworkQuery
+	if all.ProcessQuery != nil && all.ProcessQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProcessQuery = all.ProcessQuery
+	if all.ProfileMetricsQuery != nil && all.ProfileMetricsQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProfileMetricsQuery = all.ProfileMetricsQuery
 	o.Q = all.Q
 	o.Queries = all.Queries
 	o.ResponseFormat = all.ResponseFormat
+	if all.RumQuery != nil && all.RumQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.RumQuery = all.RumQuery
+	if all.SecurityQuery != nil && all.SecurityQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SecurityQuery = all.SecurityQuery
 	return nil
 }

--- a/api/v1/datadog/model_response_meta_attributes.go
+++ b/api/v1/datadog/model_response_meta_attributes.go
@@ -97,6 +97,13 @@ func (o *ResponseMetaAttributes) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	return nil
 }

--- a/api/v1/datadog/model_scatter_plot_request.go
+++ b/api/v1/datadog/model_scatter_plot_request.go
@@ -448,14 +448,70 @@ func (o *ScatterPlotRequest) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Aggregator = all.Aggregator
+	if all.ApmQuery != nil && all.ApmQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApmQuery = all.ApmQuery
+	if all.EventQuery != nil && all.EventQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.EventQuery = all.EventQuery
+	if all.LogQuery != nil && all.LogQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogQuery = all.LogQuery
+	if all.NetworkQuery != nil && all.NetworkQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.NetworkQuery = all.NetworkQuery
+	if all.ProcessQuery != nil && all.ProcessQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProcessQuery = all.ProcessQuery
+	if all.ProfileMetricsQuery != nil && all.ProfileMetricsQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProfileMetricsQuery = all.ProfileMetricsQuery
 	o.Q = all.Q
+	if all.RumQuery != nil && all.RumQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.RumQuery = all.RumQuery
+	if all.SecurityQuery != nil && all.SecurityQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SecurityQuery = all.SecurityQuery
 	return nil
 }

--- a/api/v1/datadog/model_scatter_plot_widget_definition.go
+++ b/api/v1/datadog/model_scatter_plot_widget_definition.go
@@ -454,13 +454,41 @@ func (o *ScatterPlotWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.ColorByGroups = all.ColorByGroups
 	o.CustomLinks = all.CustomLinks
+	if all.Requests.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Requests = all.Requests
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign
 	o.TitleSize = all.TitleSize
 	o.Type = all.Type
+	if all.Xaxis != nil && all.Xaxis.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Xaxis = all.Xaxis
+	if all.Yaxis != nil && all.Yaxis.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Yaxis = all.Yaxis
 	return nil
 }

--- a/api/v1/datadog/model_scatter_plot_widget_definition_requests.go
+++ b/api/v1/datadog/model_scatter_plot_widget_definition_requests.go
@@ -173,8 +173,29 @@ func (o *ScatterPlotWidgetDefinitionRequests) UnmarshalJSON(bytes []byte) (err e
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Table != nil && all.Table.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Table = all.Table
+	if all.X != nil && all.X.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.X = all.X
+	if all.Y != nil && all.Y.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Y = all.Y
 	return nil
 }

--- a/api/v1/datadog/model_service_level_objective.go
+++ b/api/v1/datadog/model_service_level_objective.go
@@ -587,6 +587,13 @@ func (o *ServiceLevelObjective) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.CreatedAt = all.CreatedAt
+	if all.Creator != nil && all.Creator.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Creator = all.Creator
 	o.Description = all.Description
 	o.Groups = all.Groups
@@ -595,6 +602,13 @@ func (o *ServiceLevelObjective) UnmarshalJSON(bytes []byte) (err error) {
 	o.MonitorIds = all.MonitorIds
 	o.MonitorTags = all.MonitorTags
 	o.Name = all.Name
+	if all.Query != nil && all.Query.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Query = all.Query
 	o.Tags = all.Tags
 	o.Thresholds = all.Thresholds

--- a/api/v1/datadog/model_service_level_objective_request.go
+++ b/api/v1/datadog/model_service_level_objective_request.go
@@ -389,6 +389,13 @@ func (o *ServiceLevelObjectiveRequest) UnmarshalJSON(bytes []byte) (err error) {
 	o.Groups = all.Groups
 	o.MonitorIds = all.MonitorIds
 	o.Name = all.Name
+	if all.Query != nil && all.Query.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Query = all.Query
 	o.Tags = all.Tags
 	o.Thresholds = all.Thresholds

--- a/api/v1/datadog/model_service_summary_widget_definition.go
+++ b/api/v1/datadog/model_service_summary_widget_definition.go
@@ -695,6 +695,13 @@ func (o *ServiceSummaryWidgetDefinition) UnmarshalJSON(bytes []byte) (err error)
 	o.ShowResourceList = all.ShowResourceList
 	o.SizeFormat = all.SizeFormat
 	o.SpanName = all.SpanName
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign

--- a/api/v1/datadog/model_slack_integration_channel.go
+++ b/api/v1/datadog/model_slack_integration_channel.go
@@ -135,6 +135,13 @@ func (o *SlackIntegrationChannel) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Display != nil && all.Display.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Display = all.Display
 	o.Name = all.Name
 	return nil

--- a/api/v1/datadog/model_slo_bulk_delete_response.go
+++ b/api/v1/datadog/model_slo_bulk_delete_response.go
@@ -140,6 +140,13 @@ func (o *SLOBulkDeleteResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	o.Errors = all.Errors
 	return nil

--- a/api/v1/datadog/model_slo_correction.go
+++ b/api/v1/datadog/model_slo_correction.go
@@ -185,6 +185,13 @@ func (o *SLOCorrection) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v1/datadog/model_slo_correction_create_data.go
+++ b/api/v1/datadog/model_slo_correction_create_data.go
@@ -146,6 +146,13 @@ func (o *SLOCorrectionCreateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Type = all.Type
 	return nil

--- a/api/v1/datadog/model_slo_correction_create_request.go
+++ b/api/v1/datadog/model_slo_correction_create_request.go
@@ -97,6 +97,13 @@ func (o *SLOCorrectionCreateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v1/datadog/model_slo_correction_list_response.go
+++ b/api/v1/datadog/model_slo_correction_list_response.go
@@ -136,6 +136,13 @@ func (o *SLOCorrectionListResponse) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Data = all.Data
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v1/datadog/model_slo_correction_response.go
+++ b/api/v1/datadog/model_slo_correction_response.go
@@ -97,6 +97,13 @@ func (o *SLOCorrectionResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v1/datadog/model_slo_correction_response_attributes.go
+++ b/api/v1/datadog/model_slo_correction_response_attributes.go
@@ -559,6 +559,13 @@ func (o *SLOCorrectionResponseAttributes) UnmarshalJSON(bytes []byte) (err error
 	}
 	o.Category = all.Category
 	o.CreatedAt = all.CreatedAt
+	if all.Creator != nil && all.Creator.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Creator = all.Creator
 	o.Description = all.Description
 	o.Duration = all.Duration

--- a/api/v1/datadog/model_slo_correction_update_data.go
+++ b/api/v1/datadog/model_slo_correction_update_data.go
@@ -147,6 +147,13 @@ func (o *SLOCorrectionUpdateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Type = all.Type
 	return nil

--- a/api/v1/datadog/model_slo_correction_update_request.go
+++ b/api/v1/datadog/model_slo_correction_update_request.go
@@ -97,6 +97,13 @@ func (o *SLOCorrectionUpdateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v1/datadog/model_slo_history_metrics.go
+++ b/api/v1/datadog/model_slo_history_metrics.go
@@ -332,9 +332,23 @@ func (o *SLOHistoryMetrics) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Denominator.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Denominator = all.Denominator
 	o.Interval = all.Interval
 	o.Message = all.Message
+	if all.Numerator.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Numerator = all.Numerator
 	o.Query = all.Query
 	o.ResType = all.ResType

--- a/api/v1/datadog/model_slo_history_metrics_series.go
+++ b/api/v1/datadog/model_slo_history_metrics_series.go
@@ -202,6 +202,13 @@ func (o *SLOHistoryMetricsSeries) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Count = all.Count
+	if all.Metadata != nil && all.Metadata.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Metadata = all.Metadata
 	o.Sum = all.Sum
 	o.Values = all.Values

--- a/api/v1/datadog/model_slo_history_response.go
+++ b/api/v1/datadog/model_slo_history_response.go
@@ -135,6 +135,13 @@ func (o *SLOHistoryResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	o.Errors = all.Errors
 	return nil

--- a/api/v1/datadog/model_slo_history_response_data.go
+++ b/api/v1/datadog/model_slo_history_response_data.go
@@ -470,7 +470,21 @@ func (o *SLOHistoryResponseData) UnmarshalJSON(bytes []byte) (err error) {
 	o.GroupBy = all.GroupBy
 	o.Groups = all.Groups
 	o.Monitors = all.Monitors
+	if all.Overall != nil && all.Overall.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Overall = all.Overall
+	if all.Series != nil && all.Series.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Series = all.Series
 	o.Thresholds = all.Thresholds
 	o.ToTs = all.ToTs

--- a/api/v1/datadog/model_slo_list_response.go
+++ b/api/v1/datadog/model_slo_list_response.go
@@ -176,6 +176,13 @@ func (o *SLOListResponse) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.Data = all.Data
 	o.Errors = all.Errors
+	if all.Metadata != nil && all.Metadata.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Metadata = all.Metadata
 	return nil
 }

--- a/api/v1/datadog/model_slo_list_response_metadata.go
+++ b/api/v1/datadog/model_slo_list_response_metadata.go
@@ -97,6 +97,13 @@ func (o *SLOListResponseMetadata) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	return nil
 }

--- a/api/v1/datadog/model_slo_response.go
+++ b/api/v1/datadog/model_slo_response.go
@@ -137,6 +137,13 @@ func (o *SLOResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	o.Errors = all.Errors
 	return nil

--- a/api/v1/datadog/model_slo_response_data.go
+++ b/api/v1/datadog/model_slo_response_data.go
@@ -637,6 +637,13 @@ func (o *SLOResponseData) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.ConfiguredAlertIds = all.ConfiguredAlertIds
 	o.CreatedAt = all.CreatedAt
+	if all.Creator != nil && all.Creator.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Creator = all.Creator
 	o.Description = all.Description
 	o.Groups = all.Groups
@@ -645,6 +652,13 @@ func (o *SLOResponseData) UnmarshalJSON(bytes []byte) (err error) {
 	o.MonitorIds = all.MonitorIds
 	o.MonitorTags = all.MonitorTags
 	o.Name = all.Name
+	if all.Query != nil && all.Query.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Query = all.Query
 	o.Tags = all.Tags
 	o.Thresholds = all.Thresholds

--- a/api/v1/datadog/model_sunburst_widget_definition.go
+++ b/api/v1/datadog/model_sunburst_widget_definition.go
@@ -418,6 +418,13 @@ func (o *SunburstWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 	o.HideTotal = all.HideTotal
 	o.Legend = all.Legend
 	o.Requests = all.Requests
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign

--- a/api/v1/datadog/model_sunburst_widget_request.go
+++ b/api/v1/datadog/model_sunburst_widget_request.go
@@ -561,18 +561,81 @@ func (o *SunburstWidgetRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.ApmQuery != nil && all.ApmQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApmQuery = all.ApmQuery
+	if all.AuditQuery != nil && all.AuditQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.AuditQuery = all.AuditQuery
+	if all.EventQuery != nil && all.EventQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.EventQuery = all.EventQuery
 	o.Formulas = all.Formulas
+	if all.LogQuery != nil && all.LogQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogQuery = all.LogQuery
+	if all.NetworkQuery != nil && all.NetworkQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.NetworkQuery = all.NetworkQuery
+	if all.ProcessQuery != nil && all.ProcessQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProcessQuery = all.ProcessQuery
+	if all.ProfileMetricsQuery != nil && all.ProfileMetricsQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProfileMetricsQuery = all.ProfileMetricsQuery
 	o.Q = all.Q
 	o.Queries = all.Queries
 	o.ResponseFormat = all.ResponseFormat
+	if all.RumQuery != nil && all.RumQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.RumQuery = all.RumQuery
+	if all.SecurityQuery != nil && all.SecurityQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SecurityQuery = all.SecurityQuery
 	return nil
 }

--- a/api/v1/datadog/model_synthetics_api_step.go
+++ b/api/v1/datadog/model_synthetics_api_step.go
@@ -360,7 +360,21 @@ func (o *SyntheticsAPIStep) UnmarshalJSON(bytes []byte) (err error) {
 	o.ExtractedValues = all.ExtractedValues
 	o.IsCritical = all.IsCritical
 	o.Name = all.Name
+	if all.Request.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Request = all.Request
+	if all.Retry != nil && all.Retry.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Retry = all.Retry
 	o.Subtype = all.Subtype
 	return nil

--- a/api/v1/datadog/model_synthetics_api_test_.go
+++ b/api/v1/datadog/model_synthetics_api_test_.go
@@ -482,11 +482,25 @@ func (o *SyntheticsAPITest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Config.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Config = all.Config
 	o.Locations = all.Locations
 	o.Message = all.Message
 	o.MonitorId = all.MonitorId
 	o.Name = all.Name
+	if all.Options.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Options = all.Options
 	o.PublicId = all.PublicId
 	o.Status = all.Status

--- a/api/v1/datadog/model_synthetics_api_test_config.go
+++ b/api/v1/datadog/model_synthetics_api_test_config.go
@@ -213,6 +213,13 @@ func (o *SyntheticsAPITestConfig) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.Assertions = all.Assertions
 	o.ConfigVariables = all.ConfigVariables
+	if all.Request != nil && all.Request.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Request = all.Request
 	o.Steps = all.Steps
 	return nil

--- a/api/v1/datadog/model_synthetics_api_test_result_data.go
+++ b/api/v1/datadog/model_synthetics_api_test_result_data.go
@@ -410,14 +410,35 @@ func (o *SyntheticsAPITestResultData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Cert != nil && all.Cert.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Cert = all.Cert
 	o.EventType = all.EventType
+	if all.Failure != nil && all.Failure.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Failure = all.Failure
 	o.HttpStatusCode = all.HttpStatusCode
 	o.RequestHeaders = all.RequestHeaders
 	o.ResponseBody = all.ResponseBody
 	o.ResponseHeaders = all.ResponseHeaders
 	o.ResponseSize = all.ResponseSize
+	if all.Timings != nil && all.Timings.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Timings = all.Timings
 	return nil
 }

--- a/api/v1/datadog/model_synthetics_api_test_result_full.go
+++ b/api/v1/datadog/model_synthetics_api_test_result_full.go
@@ -336,10 +336,24 @@ func (o *SyntheticsAPITestResultFull) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Check != nil && all.Check.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Check = all.Check
 	o.CheckTime = all.CheckTime
 	o.CheckVersion = all.CheckVersion
 	o.ProbeDc = all.ProbeDc
+	if all.Result != nil && all.Result.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Result = all.Result
 	o.ResultId = all.ResultId
 	o.Status = all.Status

--- a/api/v1/datadog/model_synthetics_api_test_result_full_check.go
+++ b/api/v1/datadog/model_synthetics_api_test_result_full_check.go
@@ -98,6 +98,13 @@ func (o *SyntheticsAPITestResultFullCheck) UnmarshalJSON(bytes []byte) (err erro
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Config.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Config = all.Config
 	return nil
 }

--- a/api/v1/datadog/model_synthetics_api_test_result_short.go
+++ b/api/v1/datadog/model_synthetics_api_test_result_short.go
@@ -262,6 +262,13 @@ func (o *SyntheticsAPITestResultShort) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.CheckTime = all.CheckTime
 	o.ProbeDc = all.ProbeDc
+	if all.Result != nil && all.Result.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Result = all.Result
 	o.ResultId = all.ResultId
 	o.Status = all.Status

--- a/api/v1/datadog/model_synthetics_api_test_result_short_result.go
+++ b/api/v1/datadog/model_synthetics_api_test_result_short_result.go
@@ -137,6 +137,13 @@ func (o *SyntheticsAPITestResultShortResult) UnmarshalJSON(bytes []byte) (err er
 		return nil
 	}
 	o.Passed = all.Passed
+	if all.Timings != nil && all.Timings.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Timings = all.Timings
 	return nil
 }

--- a/api/v1/datadog/model_synthetics_assertion_json_path_target.go
+++ b/api/v1/datadog/model_synthetics_assertion_json_path_target.go
@@ -224,6 +224,13 @@ func (o *SyntheticsAssertionJSONPathTarget) UnmarshalJSON(bytes []byte) (err err
 	}
 	o.Operator = all.Operator
 	o.Property = all.Property
+	if all.Target != nil && all.Target.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Target = all.Target
 	o.Type = all.Type
 	return nil

--- a/api/v1/datadog/model_synthetics_batch_details.go
+++ b/api/v1/datadog/model_synthetics_batch_details.go
@@ -97,6 +97,13 @@ func (o *SyntheticsBatchDetails) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v1/datadog/model_synthetics_batch_details_data.go
+++ b/api/v1/datadog/model_synthetics_batch_details_data.go
@@ -181,6 +181,13 @@ func (o *SyntheticsBatchDetailsData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Metadata != nil && all.Metadata.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Metadata = all.Metadata
 	o.Results = all.Results
 	o.Status = all.Status

--- a/api/v1/datadog/model_synthetics_browser_test_.go
+++ b/api/v1/datadog/model_synthetics_browser_test_.go
@@ -473,11 +473,25 @@ func (o *SyntheticsBrowserTest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Config.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Config = all.Config
 	o.Locations = all.Locations
 	o.Message = all.Message
 	o.MonitorId = all.MonitorId
 	o.Name = all.Name
+	if all.Options.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Options = all.Options
 	o.PublicId = all.PublicId
 	o.Status = all.Status

--- a/api/v1/datadog/model_synthetics_browser_test_config.go
+++ b/api/v1/datadog/model_synthetics_browser_test_config.go
@@ -246,6 +246,13 @@ func (o *SyntheticsBrowserTestConfig) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.Assertions = all.Assertions
 	o.ConfigVariables = all.ConfigVariables
+	if all.Request.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Request = all.Request
 	o.SetCookie = all.SetCookie
 	o.Variables = all.Variables

--- a/api/v1/datadog/model_synthetics_browser_test_result_data.go
+++ b/api/v1/datadog/model_synthetics_browser_test_result_data.go
@@ -518,9 +518,23 @@ func (o *SyntheticsBrowserTestResultData) UnmarshalJSON(bytes []byte) (err error
 	}
 	o.BrowserType = all.BrowserType
 	o.BrowserVersion = all.BrowserVersion
+	if all.Device != nil && all.Device.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Device = all.Device
 	o.Duration = all.Duration
 	o.Error = all.Error
+	if all.Failure != nil && all.Failure.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Failure = all.Failure
 	o.Passed = all.Passed
 	o.ReceivedEmailCount = all.ReceivedEmailCount

--- a/api/v1/datadog/model_synthetics_browser_test_result_full.go
+++ b/api/v1/datadog/model_synthetics_browser_test_result_full.go
@@ -336,10 +336,24 @@ func (o *SyntheticsBrowserTestResultFull) UnmarshalJSON(bytes []byte) (err error
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Check != nil && all.Check.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Check = all.Check
 	o.CheckTime = all.CheckTime
 	o.CheckVersion = all.CheckVersion
 	o.ProbeDc = all.ProbeDc
+	if all.Result != nil && all.Result.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Result = all.Result
 	o.ResultId = all.ResultId
 	o.Status = all.Status

--- a/api/v1/datadog/model_synthetics_browser_test_result_full_check.go
+++ b/api/v1/datadog/model_synthetics_browser_test_result_full_check.go
@@ -98,6 +98,13 @@ func (o *SyntheticsBrowserTestResultFullCheck) UnmarshalJSON(bytes []byte) (err 
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Config.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Config = all.Config
 	return nil
 }

--- a/api/v1/datadog/model_synthetics_browser_test_result_short.go
+++ b/api/v1/datadog/model_synthetics_browser_test_result_short.go
@@ -262,6 +262,13 @@ func (o *SyntheticsBrowserTestResultShort) UnmarshalJSON(bytes []byte) (err erro
 	}
 	o.CheckTime = all.CheckTime
 	o.ProbeDc = all.ProbeDc
+	if all.Result != nil && all.Result.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Result = all.Result
 	o.ResultId = all.ResultId
 	o.Status = all.Status

--- a/api/v1/datadog/model_synthetics_browser_test_result_short_result.go
+++ b/api/v1/datadog/model_synthetics_browser_test_result_short_result.go
@@ -249,6 +249,13 @@ func (o *SyntheticsBrowserTestResultShortResult) UnmarshalJSON(bytes []byte) (er
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Device != nil && all.Device.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Device = all.Device
 	o.Duration = all.Duration
 	o.ErrorCount = all.ErrorCount

--- a/api/v1/datadog/model_synthetics_ci_batch_metadata.go
+++ b/api/v1/datadog/model_synthetics_ci_batch_metadata.go
@@ -135,7 +135,21 @@ func (o *SyntheticsCIBatchMetadata) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Ci != nil && all.Ci.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Ci = all.Ci
+	if all.Git != nil && all.Git.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Git = all.Git
 	return nil
 }

--- a/api/v1/datadog/model_synthetics_ci_batch_metadata_ci.go
+++ b/api/v1/datadog/model_synthetics_ci_batch_metadata_ci.go
@@ -135,7 +135,21 @@ func (o *SyntheticsCIBatchMetadataCI) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Pipeline != nil && all.Pipeline.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Pipeline = all.Pipeline
+	if all.Provider != nil && all.Provider.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Provider = all.Provider
 	return nil
 }

--- a/api/v1/datadog/model_synthetics_ci_test_.go
+++ b/api/v1/datadog/model_synthetics_ci_test_.go
@@ -601,8 +601,22 @@ func (o *SyntheticsCITest) UnmarshalJSON(bytes []byte) (err error) {
 	o.FollowRedirects = all.FollowRedirects
 	o.Headers = all.Headers
 	o.Locations = all.Locations
+	if all.Metadata != nil && all.Metadata.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Metadata = all.Metadata
 	o.PublicId = all.PublicId
+	if all.Retry != nil && all.Retry.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Retry = all.Retry
 	o.StartUrl = all.StartUrl
 	o.Variables = all.Variables

--- a/api/v1/datadog/model_synthetics_global_variable.go
+++ b/api/v1/datadog/model_synthetics_global_variable.go
@@ -346,13 +346,34 @@ func (o *SyntheticsGlobalVariable) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Description = all.Description
 	o.Id = all.Id
 	o.Name = all.Name
+	if all.ParseTestOptions != nil && all.ParseTestOptions.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ParseTestOptions = all.ParseTestOptions
 	o.ParseTestPublicId = all.ParseTestPublicId
 	o.Tags = all.Tags
+	if all.Value.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Value = all.Value
 	return nil
 }

--- a/api/v1/datadog/model_synthetics_global_variable_parse_test_options.go
+++ b/api/v1/datadog/model_synthetics_global_variable_parse_test_options.go
@@ -177,6 +177,13 @@ func (o *SyntheticsGlobalVariableParseTestOptions) UnmarshalJSON(bytes []byte) (
 		return nil
 	}
 	o.Field = all.Field
+	if all.Parser.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Parser = all.Parser
 	o.Type = all.Type
 	return nil

--- a/api/v1/datadog/model_synthetics_parsing_options.go
+++ b/api/v1/datadog/model_synthetics_parsing_options.go
@@ -221,6 +221,13 @@ func (o *SyntheticsParsingOptions) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.Field = all.Field
 	o.Name = all.Name
+	if all.Parser != nil && all.Parser.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Parser = all.Parser
 	o.Type = all.Type
 	return nil

--- a/api/v1/datadog/model_synthetics_private_location.go
+++ b/api/v1/datadog/model_synthetics_private_location.go
@@ -241,6 +241,13 @@ func (o *SyntheticsPrivateLocation) UnmarshalJSON(bytes []byte) (err error) {
 	o.Description = all.Description
 	o.Id = all.Id
 	o.Name = all.Name
+	if all.Secrets != nil && all.Secrets.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Secrets = all.Secrets
 	o.Tags = all.Tags
 	return nil

--- a/api/v1/datadog/model_synthetics_private_location_creation_response.go
+++ b/api/v1/datadog/model_synthetics_private_location_creation_response.go
@@ -174,7 +174,21 @@ func (o *SyntheticsPrivateLocationCreationResponse) UnmarshalJSON(bytes []byte) 
 		return nil
 	}
 	o.Config = all.Config
+	if all.PrivateLocation != nil && all.PrivateLocation.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.PrivateLocation = all.PrivateLocation
+	if all.ResultEncryption != nil && all.ResultEncryption.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ResultEncryption = all.ResultEncryption
 	return nil
 }

--- a/api/v1/datadog/model_synthetics_private_location_secrets.go
+++ b/api/v1/datadog/model_synthetics_private_location_secrets.go
@@ -135,7 +135,21 @@ func (o *SyntheticsPrivateLocationSecrets) UnmarshalJSON(bytes []byte) (err erro
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Authentication != nil && all.Authentication.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Authentication = all.Authentication
+	if all.ConfigDecryption != nil && all.ConfigDecryption.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ConfigDecryption = all.ConfigDecryption
 	return nil
 }

--- a/api/v1/datadog/model_synthetics_ssl_certificate.go
+++ b/api/v1/datadog/model_synthetics_ssl_certificate.go
@@ -521,10 +521,24 @@ func (o *SyntheticsSSLCertificate) UnmarshalJSON(bytes []byte) (err error) {
 	o.ExtKeyUsage = all.ExtKeyUsage
 	o.Fingerprint = all.Fingerprint
 	o.Fingerprint256 = all.Fingerprint256
+	if all.Issuer != nil && all.Issuer.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Issuer = all.Issuer
 	o.Modulus = all.Modulus
 	o.Protocol = all.Protocol
 	o.SerialNumber = all.SerialNumber
+	if all.Subject != nil && all.Subject.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Subject = all.Subject
 	o.ValidFrom = all.ValidFrom
 	o.ValidTo = all.ValidTo

--- a/api/v1/datadog/model_synthetics_test_config.go
+++ b/api/v1/datadog/model_synthetics_test_config.go
@@ -213,6 +213,13 @@ func (o *SyntheticsTestConfig) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.Assertions = all.Assertions
 	o.ConfigVariables = all.ConfigVariables
+	if all.Request != nil && all.Request.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Request = all.Request
 	o.Variables = all.Variables
 	return nil

--- a/api/v1/datadog/model_synthetics_test_details.go
+++ b/api/v1/datadog/model_synthetics_test_details.go
@@ -579,12 +579,33 @@ func (o *SyntheticsTestDetails) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Config != nil && all.Config.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Config = all.Config
+	if all.Creator != nil && all.Creator.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Creator = all.Creator
 	o.Locations = all.Locations
 	o.Message = all.Message
 	o.MonitorId = all.MonitorId
 	o.Name = all.Name
+	if all.Options != nil && all.Options.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Options = all.Options
 	o.PublicId = all.PublicId
 	o.Status = all.Status

--- a/api/v1/datadog/model_synthetics_test_options.go
+++ b/api/v1/datadog/model_synthetics_test_options.go
@@ -603,9 +603,23 @@ func (o *SyntheticsTestOptions) UnmarshalJSON(bytes []byte) (err error) {
 	o.MinFailureDuration = all.MinFailureDuration
 	o.MinLocationFailed = all.MinLocationFailed
 	o.MonitorName = all.MonitorName
+	if all.MonitorOptions != nil && all.MonitorOptions.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.MonitorOptions = all.MonitorOptions
 	o.MonitorPriority = all.MonitorPriority
 	o.NoScreenshot = all.NoScreenshot
+	if all.Retry != nil && all.Retry.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Retry = all.Retry
 	o.TickEvery = all.TickEvery
 	return nil

--- a/api/v1/datadog/model_synthetics_test_request.go
+++ b/api/v1/datadog/model_synthetics_test_request.go
@@ -832,6 +832,13 @@ func (o *SyntheticsTestRequest) UnmarshalJSON(bytes []byte) (err error) {
 	o.AllowInsecure = all.AllowInsecure
 	o.BasicAuth = all.BasicAuth
 	o.Body = all.Body
+	if all.Certificate != nil && all.Certificate.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Certificate = all.Certificate
 	o.DnsServer = all.DnsServer
 	o.DnsServerPort = all.DnsServerPort
@@ -843,6 +850,13 @@ func (o *SyntheticsTestRequest) UnmarshalJSON(bytes []byte) (err error) {
 	o.NoSavingResponseBody = all.NoSavingResponseBody
 	o.NumberOfPackets = all.NumberOfPackets
 	o.Port = all.Port
+	if all.Proxy != nil && all.Proxy.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Proxy = all.Proxy
 	o.Query = all.Query
 	o.Servername = all.Servername

--- a/api/v1/datadog/model_synthetics_test_request_certificate.go
+++ b/api/v1/datadog/model_synthetics_test_request_certificate.go
@@ -135,7 +135,21 @@ func (o *SyntheticsTestRequestCertificate) UnmarshalJSON(bytes []byte) (err erro
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Cert != nil && all.Cert.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Cert = all.Cert
+	if all.Key != nil && all.Key.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Key = all.Key
 	return nil
 }

--- a/api/v1/datadog/model_synthetics_trigger_test_.go
+++ b/api/v1/datadog/model_synthetics_trigger_test_.go
@@ -136,6 +136,13 @@ func (o *SyntheticsTriggerTest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Metadata != nil && all.Metadata.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Metadata = all.Metadata
 	o.PublicId = all.PublicId
 	return nil

--- a/api/v1/datadog/model_table_widget_definition.go
+++ b/api/v1/datadog/model_table_widget_definition.go
@@ -387,6 +387,13 @@ func (o *TableWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 	o.CustomLinks = all.CustomLinks
 	o.HasSearchBar = all.HasSearchBar
 	o.Requests = all.Requests
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign

--- a/api/v1/datadog/model_table_widget_request.go
+++ b/api/v1/datadog/model_table_widget_request.go
@@ -807,22 +807,85 @@ func (o *TableWidgetRequest) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.Aggregator = all.Aggregator
 	o.Alias = all.Alias
+	if all.ApmQuery != nil && all.ApmQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApmQuery = all.ApmQuery
+	if all.ApmStatsQuery != nil && all.ApmStatsQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApmStatsQuery = all.ApmStatsQuery
 	o.CellDisplayMode = all.CellDisplayMode
 	o.ConditionalFormats = all.ConditionalFormats
+	if all.EventQuery != nil && all.EventQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.EventQuery = all.EventQuery
 	o.Formulas = all.Formulas
 	o.Limit = all.Limit
+	if all.LogQuery != nil && all.LogQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogQuery = all.LogQuery
+	if all.NetworkQuery != nil && all.NetworkQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.NetworkQuery = all.NetworkQuery
 	o.Order = all.Order
+	if all.ProcessQuery != nil && all.ProcessQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProcessQuery = all.ProcessQuery
+	if all.ProfileMetricsQuery != nil && all.ProfileMetricsQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProfileMetricsQuery = all.ProfileMetricsQuery
 	o.Q = all.Q
 	o.Queries = all.Queries
 	o.ResponseFormat = all.ResponseFormat
+	if all.RumQuery != nil && all.RumQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.RumQuery = all.RumQuery
+	if all.SecurityQuery != nil && all.SecurityQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SecurityQuery = all.SecurityQuery
 	return nil
 }

--- a/api/v1/datadog/model_timeseries_widget_definition.go
+++ b/api/v1/datadog/model_timeseries_widget_definition.go
@@ -657,13 +657,34 @@ func (o *TimeseriesWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 	o.LegendSize = all.LegendSize
 	o.Markers = all.Markers
 	o.Requests = all.Requests
+	if all.RightYaxis != nil && all.RightYaxis.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.RightYaxis = all.RightYaxis
 	o.ShowLegend = all.ShowLegend
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign
 	o.TitleSize = all.TitleSize
 	o.Type = all.Type
+	if all.Yaxis != nil && all.Yaxis.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Yaxis = all.Yaxis
 	return nil
 }

--- a/api/v1/datadog/model_timeseries_widget_request.go
+++ b/api/v1/datadog/model_timeseries_widget_request.go
@@ -721,22 +721,92 @@ func (o *TimeseriesWidgetRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.ApmQuery != nil && all.ApmQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApmQuery = all.ApmQuery
+	if all.AuditQuery != nil && all.AuditQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.AuditQuery = all.AuditQuery
 	o.DisplayType = all.DisplayType
+	if all.EventQuery != nil && all.EventQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.EventQuery = all.EventQuery
 	o.Formulas = all.Formulas
+	if all.LogQuery != nil && all.LogQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogQuery = all.LogQuery
 	o.Metadata = all.Metadata
+	if all.NetworkQuery != nil && all.NetworkQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.NetworkQuery = all.NetworkQuery
 	o.OnRightYaxis = all.OnRightYaxis
+	if all.ProcessQuery != nil && all.ProcessQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProcessQuery = all.ProcessQuery
+	if all.ProfileMetricsQuery != nil && all.ProfileMetricsQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProfileMetricsQuery = all.ProfileMetricsQuery
 	o.Q = all.Q
 	o.Queries = all.Queries
 	o.ResponseFormat = all.ResponseFormat
+	if all.RumQuery != nil && all.RumQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.RumQuery = all.RumQuery
+	if all.SecurityQuery != nil && all.SecurityQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SecurityQuery = all.SecurityQuery
+	if all.Style != nil && all.Style.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Style = all.Style
 	return nil
 }

--- a/api/v1/datadog/model_toplist_widget_definition.go
+++ b/api/v1/datadog/model_toplist_widget_definition.go
@@ -340,6 +340,13 @@ func (o *ToplistWidgetDefinition) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.CustomLinks = all.CustomLinks
 	o.Requests = all.Requests
+	if all.Time != nil && all.Time.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Time = all.Time
 	o.Title = all.Title
 	o.TitleAlign = all.TitleAlign

--- a/api/v1/datadog/model_toplist_widget_request.go
+++ b/api/v1/datadog/model_toplist_widget_request.go
@@ -637,20 +637,90 @@ func (o *ToplistWidgetRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.ApmQuery != nil && all.ApmQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApmQuery = all.ApmQuery
+	if all.AuditQuery != nil && all.AuditQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.AuditQuery = all.AuditQuery
 	o.ConditionalFormats = all.ConditionalFormats
+	if all.EventQuery != nil && all.EventQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.EventQuery = all.EventQuery
 	o.Formulas = all.Formulas
+	if all.LogQuery != nil && all.LogQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogQuery = all.LogQuery
+	if all.NetworkQuery != nil && all.NetworkQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.NetworkQuery = all.NetworkQuery
+	if all.ProcessQuery != nil && all.ProcessQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProcessQuery = all.ProcessQuery
+	if all.ProfileMetricsQuery != nil && all.ProfileMetricsQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProfileMetricsQuery = all.ProfileMetricsQuery
 	o.Q = all.Q
 	o.Queries = all.Queries
 	o.ResponseFormat = all.ResponseFormat
+	if all.RumQuery != nil && all.RumQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.RumQuery = all.RumQuery
+	if all.SecurityQuery != nil && all.SecurityQuery.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SecurityQuery = all.SecurityQuery
+	if all.Style != nil && all.Style.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Style = all.Style
 	return nil
 }

--- a/api/v1/datadog/model_usage_attribution_body.go
+++ b/api/v1/datadog/model_usage_attribution_body.go
@@ -332,6 +332,13 @@ func (o *UsageAttributionBody) UnmarshalJSON(bytes []byte) (err error) {
 	o.TagConfigSource = all.TagConfigSource
 	o.Tags = all.Tags
 	o.UpdatedAt = all.UpdatedAt
+	if all.Values != nil && all.Values.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Values = all.Values
 	return nil
 }

--- a/api/v1/datadog/model_usage_attribution_metadata.go
+++ b/api/v1/datadog/model_usage_attribution_metadata.go
@@ -136,6 +136,13 @@ func (o *UsageAttributionMetadata) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Aggregates = all.Aggregates
+	if all.Pagination != nil && all.Pagination.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Pagination = all.Pagination
 	return nil
 }

--- a/api/v1/datadog/model_usage_attribution_response.go
+++ b/api/v1/datadog/model_usage_attribution_response.go
@@ -135,6 +135,13 @@ func (o *UsageAttributionResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Metadata != nil && all.Metadata.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Metadata = all.Metadata
 	o.Usage = all.Usage
 	return nil

--- a/api/v1/datadog/model_usage_billable_summary_hour.go
+++ b/api/v1/datadog/model_usage_billable_summary_hour.go
@@ -371,6 +371,13 @@ func (o *UsageBillableSummaryHour) UnmarshalJSON(bytes []byte) (err error) {
 	o.PublicId = all.PublicId
 	o.RatioInMonth = all.RatioInMonth
 	o.StartDate = all.StartDate
+	if all.Usage != nil && all.Usage.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Usage = all.Usage
 	return nil
 }

--- a/api/v1/datadog/model_usage_billable_summary_keys.go
+++ b/api/v1/datadog/model_usage_billable_summary_keys.go
@@ -1275,37 +1275,261 @@ func (o *UsageBillableSummaryKeys) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.ApmHostSum != nil && all.ApmHostSum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApmHostSum = all.ApmHostSum
+	if all.ApmHostTop99p != nil && all.ApmHostTop99p.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApmHostTop99p = all.ApmHostTop99p
+	if all.ApmTraceSearchSum != nil && all.ApmTraceSearchSum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ApmTraceSearchSum = all.ApmTraceSearchSum
+	if all.FargateContainerAverage != nil && all.FargateContainerAverage.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.FargateContainerAverage = all.FargateContainerAverage
+	if all.InfraContainerSum != nil && all.InfraContainerSum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.InfraContainerSum = all.InfraContainerSum
+	if all.InfraHostSum != nil && all.InfraHostSum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.InfraHostSum = all.InfraHostSum
+	if all.InfraHostTop99p != nil && all.InfraHostTop99p.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.InfraHostTop99p = all.InfraHostTop99p
+	if all.IotTop99p != nil && all.IotTop99p.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.IotTop99p = all.IotTop99p
+	if all.LambdaFunctionAverage != nil && all.LambdaFunctionAverage.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LambdaFunctionAverage = all.LambdaFunctionAverage
+	if all.LogsIndexed15daySum != nil && all.LogsIndexed15daySum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogsIndexed15daySum = all.LogsIndexed15daySum
+	if all.LogsIndexed180daySum != nil && all.LogsIndexed180daySum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogsIndexed180daySum = all.LogsIndexed180daySum
+	if all.LogsIndexed30daySum != nil && all.LogsIndexed30daySum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogsIndexed30daySum = all.LogsIndexed30daySum
+	if all.LogsIndexed3daySum != nil && all.LogsIndexed3daySum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogsIndexed3daySum = all.LogsIndexed3daySum
+	if all.LogsIndexed45daySum != nil && all.LogsIndexed45daySum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogsIndexed45daySum = all.LogsIndexed45daySum
+	if all.LogsIndexed60daySum != nil && all.LogsIndexed60daySum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogsIndexed60daySum = all.LogsIndexed60daySum
+	if all.LogsIndexed7daySum != nil && all.LogsIndexed7daySum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogsIndexed7daySum = all.LogsIndexed7daySum
+	if all.LogsIndexed90daySum != nil && all.LogsIndexed90daySum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogsIndexed90daySum = all.LogsIndexed90daySum
+	if all.LogsIndexedCustomRetentionSum != nil && all.LogsIndexedCustomRetentionSum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogsIndexedCustomRetentionSum = all.LogsIndexedCustomRetentionSum
+	if all.LogsIndexedSum != nil && all.LogsIndexedSum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogsIndexedSum = all.LogsIndexedSum
+	if all.LogsIngestedSum != nil && all.LogsIngestedSum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogsIngestedSum = all.LogsIngestedSum
+	if all.NetworkDeviceTop99p != nil && all.NetworkDeviceTop99p.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.NetworkDeviceTop99p = all.NetworkDeviceTop99p
+	if all.NpmFlowSum != nil && all.NpmFlowSum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.NpmFlowSum = all.NpmFlowSum
+	if all.NpmHostSum != nil && all.NpmHostSum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.NpmHostSum = all.NpmHostSum
+	if all.NpmHostTop99p != nil && all.NpmHostTop99p.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.NpmHostTop99p = all.NpmHostTop99p
+	if all.ProfContainerSum != nil && all.ProfContainerSum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProfContainerSum = all.ProfContainerSum
+	if all.ProfHostTop99p != nil && all.ProfHostTop99p.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ProfHostTop99p = all.ProfHostTop99p
+	if all.RumSum != nil && all.RumSum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.RumSum = all.RumSum
+	if all.ServerlessInvocationSum != nil && all.ServerlessInvocationSum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ServerlessInvocationSum = all.ServerlessInvocationSum
+	if all.SiemSum != nil && all.SiemSum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SiemSum = all.SiemSum
+	if all.SyntheticsApiTestsSum != nil && all.SyntheticsApiTestsSum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SyntheticsApiTestsSum = all.SyntheticsApiTestsSum
+	if all.SyntheticsBrowserChecksSum != nil && all.SyntheticsBrowserChecksSum.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SyntheticsBrowserChecksSum = all.SyntheticsBrowserChecksSum
+	if all.TimeseriesAverage != nil && all.TimeseriesAverage.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.TimeseriesAverage = all.TimeseriesAverage
 	return nil
 }

--- a/api/v1/datadog/model_usage_custom_reports_data.go
+++ b/api/v1/datadog/model_usage_custom_reports_data.go
@@ -185,6 +185,13 @@ func (o *UsageCustomReportsData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v1/datadog/model_usage_custom_reports_meta.go
+++ b/api/v1/datadog/model_usage_custom_reports_meta.go
@@ -97,6 +97,13 @@ func (o *UsageCustomReportsMeta) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	return nil
 }

--- a/api/v1/datadog/model_usage_custom_reports_response.go
+++ b/api/v1/datadog/model_usage_custom_reports_response.go
@@ -136,6 +136,13 @@ func (o *UsageCustomReportsResponse) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Data = all.Data
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v1/datadog/model_usage_specified_custom_reports_data.go
+++ b/api/v1/datadog/model_usage_specified_custom_reports_data.go
@@ -185,6 +185,13 @@ func (o *UsageSpecifiedCustomReportsData) UnmarshalJSON(bytes []byte) (err error
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v1/datadog/model_usage_specified_custom_reports_meta.go
+++ b/api/v1/datadog/model_usage_specified_custom_reports_meta.go
@@ -97,6 +97,13 @@ func (o *UsageSpecifiedCustomReportsMeta) UnmarshalJSON(bytes []byte) (err error
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	return nil
 }

--- a/api/v1/datadog/model_usage_specified_custom_reports_response.go
+++ b/api/v1/datadog/model_usage_specified_custom_reports_response.go
@@ -135,7 +135,21 @@ func (o *UsageSpecifiedCustomReportsResponse) UnmarshalJSON(bytes []byte) (err e
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v1/datadog/model_usage_summary_response.go
+++ b/api/v1/datadog/model_usage_summary_response.go
@@ -2841,6 +2841,13 @@ func (o *UsageSummaryResponse) UnmarshalJSON(bytes []byte) (err error) {
 	o.LastUpdated = all.LastUpdated
 	o.LiveIndexedEventsAggSum = all.LiveIndexedEventsAggSum
 	o.LiveIngestedBytesAggSum = all.LiveIngestedBytesAggSum
+	if all.LogsByRetention != nil && all.LogsByRetention.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LogsByRetention = all.LogsByRetention
 	o.MobileRumLiteSessionCountAggSum = all.MobileRumLiteSessionCountAggSum
 	o.MobileRumSessionCountAggSum = all.MobileRumSessionCountAggSum

--- a/api/v1/datadog/model_usage_top_avg_metrics_metadata.go
+++ b/api/v1/datadog/model_usage_top_avg_metrics_metadata.go
@@ -176,6 +176,13 @@ func (o *UsageTopAvgMetricsMetadata) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.Day = all.Day
 	o.Month = all.Month
+	if all.Pagination != nil && all.Pagination.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Pagination = all.Pagination
 	return nil
 }

--- a/api/v1/datadog/model_usage_top_avg_metrics_response.go
+++ b/api/v1/datadog/model_usage_top_avg_metrics_response.go
@@ -135,6 +135,13 @@ func (o *UsageTopAvgMetricsResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Metadata != nil && all.Metadata.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Metadata = all.Metadata
 	o.Usage = all.Usage
 	return nil

--- a/api/v1/datadog/model_user_response.go
+++ b/api/v1/datadog/model_user_response.go
@@ -97,6 +97,13 @@ func (o *UserResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.User != nil && all.User.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.User = all.User
 	return nil
 }

--- a/api/v1/datadog/model_widget.go
+++ b/api/v1/datadog/model_widget.go
@@ -181,6 +181,13 @@ func (o *Widget) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.Definition = all.Definition
 	o.Id = all.Id
+	if all.Layout != nil && all.Layout.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Layout = all.Layout
 	return nil
 }

--- a/api/v1/datadog/model_widget_formula.go
+++ b/api/v1/datadog/model_widget_formula.go
@@ -262,6 +262,13 @@ func (o *WidgetFormula) UnmarshalJSON(bytes []byte) (err error) {
 	o.CellDisplayMode = all.CellDisplayMode
 	o.ConditionalFormats = all.ConditionalFormats
 	o.Formula = all.Formula
+	if all.Limit != nil && all.Limit.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Limit = all.Limit
 	return nil
 }

--- a/api/v2/datadog/model_api_key_create_data.go
+++ b/api/v2/datadog/model_api_key_create_data.go
@@ -140,6 +140,13 @@ func (o *APIKeyCreateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_api_key_create_request.go
+++ b/api/v2/datadog/model_api_key_create_request.go
@@ -98,6 +98,13 @@ func (o *APIKeyCreateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_api_key_relationships.go
+++ b/api/v2/datadog/model_api_key_relationships.go
@@ -135,7 +135,21 @@ func (o *APIKeyRelationships) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.CreatedBy != nil && all.CreatedBy.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.CreatedBy = all.CreatedBy
+	if all.ModifiedBy != nil && all.ModifiedBy.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ModifiedBy = all.ModifiedBy
 	return nil
 }

--- a/api/v2/datadog/model_api_key_response.go
+++ b/api/v2/datadog/model_api_key_response.go
@@ -135,6 +135,13 @@ func (o *APIKeyResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	o.Included = all.Included
 	return nil

--- a/api/v2/datadog/model_api_key_update_data.go
+++ b/api/v2/datadog/model_api_key_update_data.go
@@ -172,6 +172,13 @@ func (o *APIKeyUpdateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_api_key_update_request.go
+++ b/api/v2/datadog/model_api_key_update_request.go
@@ -98,6 +98,13 @@ func (o *APIKeyUpdateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_application_key_create_data.go
+++ b/api/v2/datadog/model_application_key_create_data.go
@@ -140,6 +140,13 @@ func (o *ApplicationKeyCreateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_application_key_create_request.go
+++ b/api/v2/datadog/model_application_key_create_request.go
@@ -98,6 +98,13 @@ func (o *ApplicationKeyCreateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_application_key_relationships.go
+++ b/api/v2/datadog/model_application_key_relationships.go
@@ -97,6 +97,13 @@ func (o *ApplicationKeyRelationships) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.OwnedBy != nil && all.OwnedBy.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.OwnedBy = all.OwnedBy
 	return nil
 }

--- a/api/v2/datadog/model_application_key_response.go
+++ b/api/v2/datadog/model_application_key_response.go
@@ -135,6 +135,13 @@ func (o *ApplicationKeyResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	o.Included = all.Included
 	return nil

--- a/api/v2/datadog/model_application_key_update_data.go
+++ b/api/v2/datadog/model_application_key_update_data.go
@@ -172,6 +172,13 @@ func (o *ApplicationKeyUpdateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_application_key_update_request.go
+++ b/api/v2/datadog/model_application_key_update_request.go
@@ -98,6 +98,13 @@ func (o *ApplicationKeyUpdateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_audit_logs_event.go
+++ b/api/v2/datadog/model_audit_logs_event.go
@@ -185,6 +185,13 @@ func (o *AuditLogsEvent) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_audit_logs_events_response.go
+++ b/api/v2/datadog/model_audit_logs_events_response.go
@@ -174,7 +174,21 @@ func (o *AuditLogsEventsResponse) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Data = all.Data
+	if all.Links != nil && all.Links.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Links = all.Links
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v2/datadog/model_audit_logs_response_metadata.go
+++ b/api/v2/datadog/model_audit_logs_response_metadata.go
@@ -259,6 +259,13 @@ func (o *AuditLogsResponseMetadata) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Elapsed = all.Elapsed
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	o.RequestId = all.RequestId
 	o.Status = all.Status

--- a/api/v2/datadog/model_audit_logs_search_events_request.go
+++ b/api/v2/datadog/model_audit_logs_search_events_request.go
@@ -220,8 +220,29 @@ func (o *AuditLogsSearchEventsRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Filter != nil && all.Filter.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Filter = all.Filter
+	if all.Options != nil && all.Options.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Options = all.Options
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	o.Sort = all.Sort
 	return nil

--- a/api/v2/datadog/model_auth_n_mapping.go
+++ b/api/v2/datadog/model_auth_n_mapping.go
@@ -254,9 +254,23 @@ func (o *AuthNMapping) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Included = all.Included
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_auth_n_mapping_create_data.go
+++ b/api/v2/datadog/model_auth_n_mapping_create_data.go
@@ -184,7 +184,21 @@ func (o *AuthNMappingCreateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_auth_n_mapping_create_relationships.go
+++ b/api/v2/datadog/model_auth_n_mapping_create_relationships.go
@@ -97,6 +97,13 @@ func (o *AuthNMappingCreateRelationships) UnmarshalJSON(bytes []byte) (err error
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Role != nil && all.Role.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Role = all.Role
 	return nil
 }

--- a/api/v2/datadog/model_auth_n_mapping_create_request.go
+++ b/api/v2/datadog/model_auth_n_mapping_create_request.go
@@ -98,6 +98,13 @@ func (o *AuthNMappingCreateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_auth_n_mapping_relationships.go
+++ b/api/v2/datadog/model_auth_n_mapping_relationships.go
@@ -135,7 +135,21 @@ func (o *AuthNMappingRelationships) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Role != nil && all.Role.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Role = all.Role
+	if all.SamlAssertionAttribute != nil && all.SamlAssertionAttribute.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.SamlAssertionAttribute = all.SamlAssertionAttribute
 	return nil
 }

--- a/api/v2/datadog/model_auth_n_mapping_response.go
+++ b/api/v2/datadog/model_auth_n_mapping_response.go
@@ -97,6 +97,13 @@ func (o *AuthNMappingResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_auth_n_mapping_update_data.go
+++ b/api/v2/datadog/model_auth_n_mapping_update_data.go
@@ -216,8 +216,22 @@ func (o *AuthNMappingUpdateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_auth_n_mapping_update_relationships.go
+++ b/api/v2/datadog/model_auth_n_mapping_update_relationships.go
@@ -97,6 +97,13 @@ func (o *AuthNMappingUpdateRelationships) UnmarshalJSON(bytes []byte) (err error
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Role != nil && all.Role.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Role = all.Role
 	return nil
 }

--- a/api/v2/datadog/model_auth_n_mapping_update_request.go
+++ b/api/v2/datadog/model_auth_n_mapping_update_request.go
@@ -98,6 +98,13 @@ func (o *AuthNMappingUpdateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_auth_n_mappings_response.go
+++ b/api/v2/datadog/model_auth_n_mappings_response.go
@@ -136,6 +136,13 @@ func (o *AuthNMappingsResponse) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Data = all.Data
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v2/datadog/model_cloud_workload_security_agent_rule_attributes.go
+++ b/api/v2/datadog/model_cloud_workload_security_agent_rule_attributes.go
@@ -479,6 +479,13 @@ func (o *CloudWorkloadSecurityAgentRuleAttributes) UnmarshalJSON(bytes []byte) (
 	}
 	o.Category = all.Category
 	o.CreationDate = all.CreationDate
+	if all.Creator != nil && all.Creator.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Creator = all.Creator
 	o.DefaultRule = all.DefaultRule
 	o.Description = all.Description
@@ -486,6 +493,13 @@ func (o *CloudWorkloadSecurityAgentRuleAttributes) UnmarshalJSON(bytes []byte) (
 	o.Expression = all.Expression
 	o.Name = all.Name
 	o.UpdatedAt = all.UpdatedAt
+	if all.Updater != nil && all.Updater.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Updater = all.Updater
 	o.Version = all.Version
 	return nil

--- a/api/v2/datadog/model_cloud_workload_security_agent_rule_create_data.go
+++ b/api/v2/datadog/model_cloud_workload_security_agent_rule_create_data.go
@@ -140,6 +140,13 @@ func (o *CloudWorkloadSecurityAgentRuleCreateData) UnmarshalJSON(bytes []byte) (
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_cloud_workload_security_agent_rule_create_request.go
+++ b/api/v2/datadog/model_cloud_workload_security_agent_rule_create_request.go
@@ -98,6 +98,13 @@ func (o *CloudWorkloadSecurityAgentRuleCreateRequest) UnmarshalJSON(bytes []byte
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_cloud_workload_security_agent_rule_data.go
+++ b/api/v2/datadog/model_cloud_workload_security_agent_rule_data.go
@@ -185,6 +185,13 @@ func (o *CloudWorkloadSecurityAgentRuleData) UnmarshalJSON(bytes []byte) (err er
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_cloud_workload_security_agent_rule_response.go
+++ b/api/v2/datadog/model_cloud_workload_security_agent_rule_response.go
@@ -97,6 +97,13 @@ func (o *CloudWorkloadSecurityAgentRuleResponse) UnmarshalJSON(bytes []byte) (er
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_cloud_workload_security_agent_rule_update_data.go
+++ b/api/v2/datadog/model_cloud_workload_security_agent_rule_update_data.go
@@ -140,6 +140,13 @@ func (o *CloudWorkloadSecurityAgentRuleUpdateData) UnmarshalJSON(bytes []byte) (
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_cloud_workload_security_agent_rule_update_request.go
+++ b/api/v2/datadog/model_cloud_workload_security_agent_rule_update_request.go
@@ -98,6 +98,13 @@ func (o *CloudWorkloadSecurityAgentRuleUpdateRequest) UnmarshalJSON(bytes []byte
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_dashboard_list_item.go
+++ b/api/v2/datadog/model_dashboard_list_item.go
@@ -519,6 +519,13 @@ func (o *DashboardListItem) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Author != nil && all.Author.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Author = all.Author
 	o.Created = all.Created
 	o.Icon = all.Icon

--- a/api/v2/datadog/model_full_api_key.go
+++ b/api/v2/datadog/model_full_api_key.go
@@ -223,8 +223,22 @@ func (o *FullAPIKey) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_full_application_key.go
+++ b/api/v2/datadog/model_full_application_key.go
@@ -223,8 +223,22 @@ func (o *FullApplicationKey) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_incident_create_data.go
+++ b/api/v2/datadog/model_incident_create_data.go
@@ -178,7 +178,21 @@ func (o *IncidentCreateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_incident_create_relationships.go
+++ b/api/v2/datadog/model_incident_create_relationships.go
@@ -98,6 +98,13 @@ func (o *IncidentCreateRelationships) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.CommanderUser.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.CommanderUser = all.CommanderUser
 	return nil
 }

--- a/api/v2/datadog/model_incident_create_request.go
+++ b/api/v2/datadog/model_incident_create_request.go
@@ -98,6 +98,13 @@ func (o *IncidentCreateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_incident_response.go
+++ b/api/v2/datadog/model_incident_response.go
@@ -136,6 +136,13 @@ func (o *IncidentResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	o.Included = all.Included
 	return nil

--- a/api/v2/datadog/model_incident_response_data.go
+++ b/api/v2/datadog/model_incident_response_data.go
@@ -216,8 +216,22 @@ func (o *IncidentResponseData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_incident_response_meta.go
+++ b/api/v2/datadog/model_incident_response_meta.go
@@ -97,6 +97,13 @@ func (o *IncidentResponseMeta) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Pagination != nil && all.Pagination.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Pagination = all.Pagination
 	return nil
 }

--- a/api/v2/datadog/model_incident_response_relationships.go
+++ b/api/v2/datadog/model_incident_response_relationships.go
@@ -249,10 +249,45 @@ func (o *IncidentResponseRelationships) UnmarshalJSON(bytes []byte) (err error) 
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.CommanderUser != nil && all.CommanderUser.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.CommanderUser = all.CommanderUser
+	if all.CreatedByUser != nil && all.CreatedByUser.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.CreatedByUser = all.CreatedByUser
+	if all.Integrations != nil && all.Integrations.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Integrations = all.Integrations
+	if all.LastModifiedByUser != nil && all.LastModifiedByUser.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LastModifiedByUser = all.LastModifiedByUser
+	if all.Postmortem != nil && all.Postmortem.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Postmortem = all.Postmortem
 	return nil
 }

--- a/api/v2/datadog/model_incident_service_create_data.go
+++ b/api/v2/datadog/model_incident_service_create_data.go
@@ -184,7 +184,21 @@ func (o *IncidentServiceCreateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_incident_service_create_request.go
+++ b/api/v2/datadog/model_incident_service_create_request.go
@@ -98,6 +98,13 @@ func (o *IncidentServiceCreateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_incident_service_relationships.go
+++ b/api/v2/datadog/model_incident_service_relationships.go
@@ -135,7 +135,21 @@ func (o *IncidentServiceRelationships) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.CreatedBy != nil && all.CreatedBy.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.CreatedBy = all.CreatedBy
+	if all.LastModifiedBy != nil && all.LastModifiedBy.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LastModifiedBy = all.LastModifiedBy
 	return nil
 }

--- a/api/v2/datadog/model_incident_service_response.go
+++ b/api/v2/datadog/model_incident_service_response.go
@@ -136,6 +136,13 @@ func (o *IncidentServiceResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	o.Included = all.Included
 	return nil

--- a/api/v2/datadog/model_incident_service_response_data.go
+++ b/api/v2/datadog/model_incident_service_response_data.go
@@ -216,8 +216,22 @@ func (o *IncidentServiceResponseData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_incident_service_update_data.go
+++ b/api/v2/datadog/model_incident_service_update_data.go
@@ -222,8 +222,22 @@ func (o *IncidentServiceUpdateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_incident_service_update_request.go
+++ b/api/v2/datadog/model_incident_service_update_request.go
@@ -98,6 +98,13 @@ func (o *IncidentServiceUpdateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_incident_services_response.go
+++ b/api/v2/datadog/model_incident_services_response.go
@@ -176,6 +176,13 @@ func (o *IncidentServicesResponse) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.Data = all.Data
 	o.Included = all.Included
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v2/datadog/model_incident_team_create_data.go
+++ b/api/v2/datadog/model_incident_team_create_data.go
@@ -184,7 +184,21 @@ func (o *IncidentTeamCreateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_incident_team_create_request.go
+++ b/api/v2/datadog/model_incident_team_create_request.go
@@ -98,6 +98,13 @@ func (o *IncidentTeamCreateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_incident_team_relationships.go
+++ b/api/v2/datadog/model_incident_team_relationships.go
@@ -135,7 +135,21 @@ func (o *IncidentTeamRelationships) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.CreatedBy != nil && all.CreatedBy.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.CreatedBy = all.CreatedBy
+	if all.LastModifiedBy != nil && all.LastModifiedBy.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.LastModifiedBy = all.LastModifiedBy
 	return nil
 }

--- a/api/v2/datadog/model_incident_team_response.go
+++ b/api/v2/datadog/model_incident_team_response.go
@@ -136,6 +136,13 @@ func (o *IncidentTeamResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	o.Included = all.Included
 	return nil

--- a/api/v2/datadog/model_incident_team_response_data.go
+++ b/api/v2/datadog/model_incident_team_response_data.go
@@ -223,8 +223,22 @@ func (o *IncidentTeamResponseData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_incident_team_update_data.go
+++ b/api/v2/datadog/model_incident_team_update_data.go
@@ -222,8 +222,22 @@ func (o *IncidentTeamUpdateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_incident_team_update_request.go
+++ b/api/v2/datadog/model_incident_team_update_request.go
@@ -98,6 +98,13 @@ func (o *IncidentTeamUpdateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_incident_teams_response.go
+++ b/api/v2/datadog/model_incident_teams_response.go
@@ -176,6 +176,13 @@ func (o *IncidentTeamsResponse) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.Data = all.Data
 	o.Included = all.Included
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v2/datadog/model_incident_timeline_cell_markdown_create_attributes.go
+++ b/api/v2/datadog/model_incident_timeline_cell_markdown_create_attributes.go
@@ -183,6 +183,13 @@ func (o *IncidentTimelineCellMarkdownCreateAttributes) UnmarshalJSON(bytes []byt
 		return nil
 	}
 	o.CellType = all.CellType
+	if all.Content.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Content = all.Content
 	o.Important = all.Important
 	return nil

--- a/api/v2/datadog/model_incident_update_data.go
+++ b/api/v2/datadog/model_incident_update_data.go
@@ -216,8 +216,22 @@ func (o *IncidentUpdateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_incident_update_relationships.go
+++ b/api/v2/datadog/model_incident_update_relationships.go
@@ -173,8 +173,29 @@ func (o *IncidentUpdateRelationships) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.CommanderUser != nil && all.CommanderUser.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.CommanderUser = all.CommanderUser
+	if all.Integrations != nil && all.Integrations.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Integrations = all.Integrations
+	if all.Postmortem != nil && all.Postmortem.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Postmortem = all.Postmortem
 	return nil
 }

--- a/api/v2/datadog/model_incident_update_request.go
+++ b/api/v2/datadog/model_incident_update_request.go
@@ -98,6 +98,13 @@ func (o *IncidentUpdateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_incidents_response.go
+++ b/api/v2/datadog/model_incidents_response.go
@@ -176,6 +176,13 @@ func (o *IncidentsResponse) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.Data = all.Data
 	o.Included = all.Included
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v2/datadog/model_log.go
+++ b/api/v2/datadog/model_log.go
@@ -185,6 +185,13 @@ func (o *Log) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_logs_aggregate_request.go
+++ b/api/v2/datadog/model_logs_aggregate_request.go
@@ -251,9 +251,30 @@ func (o *LogsAggregateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Compute = all.Compute
+	if all.Filter != nil && all.Filter.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Filter = all.Filter
 	o.GroupBy = all.GroupBy
+	if all.Options != nil && all.Options.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Options = all.Options
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	return nil
 }

--- a/api/v2/datadog/model_logs_aggregate_response.go
+++ b/api/v2/datadog/model_logs_aggregate_response.go
@@ -135,7 +135,21 @@ func (o *LogsAggregateResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v2/datadog/model_logs_archive.go
+++ b/api/v2/datadog/model_logs_archive.go
@@ -97,6 +97,13 @@ func (o *LogsArchive) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_logs_archive_create_request.go
+++ b/api/v2/datadog/model_logs_archive_create_request.go
@@ -97,6 +97,13 @@ func (o *LogsArchiveCreateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_logs_archive_create_request_definition.go
+++ b/api/v2/datadog/model_logs_archive_create_request_definition.go
@@ -138,6 +138,13 @@ func (o *LogsArchiveCreateRequestDefinition) UnmarshalJSON(bytes []byte) (err er
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_logs_archive_definition.go
+++ b/api/v2/datadog/model_logs_archive_definition.go
@@ -174,6 +174,13 @@ func (o *LogsArchiveDefinition) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_logs_archive_destination_azure.go
+++ b/api/v2/datadog/model_logs_archive_destination_azure.go
@@ -281,6 +281,13 @@ func (o *LogsArchiveDestinationAzure) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Container = all.Container
+	if all.Integration.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Integration = all.Integration
 	o.Path = all.Path
 	o.Region = all.Region

--- a/api/v2/datadog/model_logs_archive_destination_gcs.go
+++ b/api/v2/datadog/model_logs_archive_destination_gcs.go
@@ -211,6 +211,13 @@ func (o *LogsArchiveDestinationGCS) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Bucket = all.Bucket
+	if all.Integration.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Integration = all.Integration
 	o.Path = all.Path
 	o.Type = all.Type

--- a/api/v2/datadog/model_logs_archive_destination_s3.go
+++ b/api/v2/datadog/model_logs_archive_destination_s3.go
@@ -211,6 +211,13 @@ func (o *LogsArchiveDestinationS3) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Bucket = all.Bucket
+	if all.Integration.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Integration = all.Integration
 	o.Path = all.Path
 	o.Type = all.Type

--- a/api/v2/datadog/model_logs_archive_order.go
+++ b/api/v2/datadog/model_logs_archive_order.go
@@ -97,6 +97,13 @@ func (o *LogsArchiveOrder) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_logs_archive_order_definition.go
+++ b/api/v2/datadog/model_logs_archive_order_definition.go
@@ -140,6 +140,13 @@ func (o *LogsArchiveOrderDefinition) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_logs_group_by.go
+++ b/api/v2/datadog/model_logs_group_by.go
@@ -294,9 +294,23 @@ func (o *LogsGroupBy) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Facet = all.Facet
+	if all.Histogram != nil && all.Histogram.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Histogram = all.Histogram
 	o.Limit = all.Limit
 	o.Missing = all.Missing
+	if all.Sort != nil && all.Sort.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Sort = all.Sort
 	o.Total = all.Total
 	return nil

--- a/api/v2/datadog/model_logs_list_request.go
+++ b/api/v2/datadog/model_logs_list_request.go
@@ -220,8 +220,29 @@ func (o *LogsListRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Filter != nil && all.Filter.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Filter = all.Filter
+	if all.Options != nil && all.Options.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Options = all.Options
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	o.Sort = all.Sort
 	return nil

--- a/api/v2/datadog/model_logs_list_response.go
+++ b/api/v2/datadog/model_logs_list_response.go
@@ -174,7 +174,21 @@ func (o *LogsListResponse) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Data = all.Data
+	if all.Links != nil && all.Links.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Links = all.Links
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v2/datadog/model_logs_metric_create_attributes.go
+++ b/api/v2/datadog/model_logs_metric_create_attributes.go
@@ -174,7 +174,21 @@ func (o *LogsMetricCreateAttributes) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Compute.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Compute = all.Compute
+	if all.Filter != nil && all.Filter.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Filter = all.Filter
 	o.GroupBy = all.GroupBy
 	return nil

--- a/api/v2/datadog/model_logs_metric_create_data.go
+++ b/api/v2/datadog/model_logs_metric_create_data.go
@@ -172,6 +172,13 @@ func (o *LogsMetricCreateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_logs_metric_create_request.go
+++ b/api/v2/datadog/model_logs_metric_create_request.go
@@ -98,6 +98,13 @@ func (o *LogsMetricCreateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_logs_metric_response.go
+++ b/api/v2/datadog/model_logs_metric_response.go
@@ -97,6 +97,13 @@ func (o *LogsMetricResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_logs_metric_response_attributes.go
+++ b/api/v2/datadog/model_logs_metric_response_attributes.go
@@ -173,7 +173,21 @@ func (o *LogsMetricResponseAttributes) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Compute != nil && all.Compute.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Compute = all.Compute
+	if all.Filter != nil && all.Filter.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Filter = all.Filter
 	o.GroupBy = all.GroupBy
 	return nil

--- a/api/v2/datadog/model_logs_metric_response_data.go
+++ b/api/v2/datadog/model_logs_metric_response_data.go
@@ -185,6 +185,13 @@ func (o *LogsMetricResponseData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_logs_metric_update_attributes.go
+++ b/api/v2/datadog/model_logs_metric_update_attributes.go
@@ -135,6 +135,13 @@ func (o *LogsMetricUpdateAttributes) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Filter != nil && all.Filter.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Filter = all.Filter
 	o.GroupBy = all.GroupBy
 	return nil

--- a/api/v2/datadog/model_logs_metric_update_data.go
+++ b/api/v2/datadog/model_logs_metric_update_data.go
@@ -140,6 +140,13 @@ func (o *LogsMetricUpdateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_logs_metric_update_request.go
+++ b/api/v2/datadog/model_logs_metric_update_request.go
@@ -98,6 +98,13 @@ func (o *LogsMetricUpdateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_logs_response_metadata.go
+++ b/api/v2/datadog/model_logs_response_metadata.go
@@ -259,6 +259,13 @@ func (o *LogsResponseMetadata) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Elapsed = all.Elapsed
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	o.RequestId = all.RequestId
 	o.Status = all.Status

--- a/api/v2/datadog/model_metric_all_tags.go
+++ b/api/v2/datadog/model_metric_all_tags.go
@@ -185,6 +185,13 @@ func (o *MetricAllTags) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_metric_all_tags_response.go
+++ b/api/v2/datadog/model_metric_all_tags_response.go
@@ -97,6 +97,13 @@ func (o *MetricAllTagsResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_metric_bulk_tag_config_create.go
+++ b/api/v2/datadog/model_metric_bulk_tag_config_create.go
@@ -178,6 +178,13 @@ func (o *MetricBulkTagConfigCreate) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_metric_bulk_tag_config_create_request.go
+++ b/api/v2/datadog/model_metric_bulk_tag_config_create_request.go
@@ -98,6 +98,13 @@ func (o *MetricBulkTagConfigCreateRequest) UnmarshalJSON(bytes []byte) (err erro
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_metric_bulk_tag_config_delete.go
+++ b/api/v2/datadog/model_metric_bulk_tag_config_delete.go
@@ -178,6 +178,13 @@ func (o *MetricBulkTagConfigDelete) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_metric_bulk_tag_config_delete_request.go
+++ b/api/v2/datadog/model_metric_bulk_tag_config_delete_request.go
@@ -98,6 +98,13 @@ func (o *MetricBulkTagConfigDeleteRequest) UnmarshalJSON(bytes []byte) (err erro
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_metric_bulk_tag_config_response.go
+++ b/api/v2/datadog/model_metric_bulk_tag_config_response.go
@@ -98,6 +98,13 @@ func (o *MetricBulkTagConfigResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_metric_bulk_tag_config_status.go
+++ b/api/v2/datadog/model_metric_bulk_tag_config_status.go
@@ -179,6 +179,13 @@ func (o *MetricBulkTagConfigStatus) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_metric_distinct_volume.go
+++ b/api/v2/datadog/model_metric_distinct_volume.go
@@ -185,6 +185,13 @@ func (o *MetricDistinctVolume) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_metric_ingested_indexed_volume.go
+++ b/api/v2/datadog/model_metric_ingested_indexed_volume.go
@@ -185,6 +185,13 @@ func (o *MetricIngestedIndexedVolume) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_metric_tag_configuration.go
+++ b/api/v2/datadog/model_metric_tag_configuration.go
@@ -185,6 +185,13 @@ func (o *MetricTagConfiguration) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_metric_tag_configuration_create_data.go
+++ b/api/v2/datadog/model_metric_tag_configuration_create_data.go
@@ -178,6 +178,13 @@ func (o *MetricTagConfigurationCreateData) UnmarshalJSON(bytes []byte) (err erro
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_metric_tag_configuration_create_request.go
+++ b/api/v2/datadog/model_metric_tag_configuration_create_request.go
@@ -98,6 +98,13 @@ func (o *MetricTagConfigurationCreateRequest) UnmarshalJSON(bytes []byte) (err e
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_metric_tag_configuration_response.go
+++ b/api/v2/datadog/model_metric_tag_configuration_response.go
@@ -97,6 +97,13 @@ func (o *MetricTagConfigurationResponse) UnmarshalJSON(bytes []byte) (err error)
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_metric_tag_configuration_update_data.go
+++ b/api/v2/datadog/model_metric_tag_configuration_update_data.go
@@ -178,6 +178,13 @@ func (o *MetricTagConfigurationUpdateData) UnmarshalJSON(bytes []byte) (err erro
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_metric_tag_configuration_update_request.go
+++ b/api/v2/datadog/model_metric_tag_configuration_update_request.go
@@ -98,6 +98,13 @@ func (o *MetricTagConfigurationUpdateRequest) UnmarshalJSON(bytes []byte) (err e
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_organization.go
+++ b/api/v2/datadog/model_organization.go
@@ -184,6 +184,13 @@ func (o *Organization) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_partial_api_key.go
+++ b/api/v2/datadog/model_partial_api_key.go
@@ -223,8 +223,22 @@ func (o *PartialAPIKey) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_partial_application_key.go
+++ b/api/v2/datadog/model_partial_application_key.go
@@ -223,8 +223,22 @@ func (o *PartialApplicationKey) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_partial_application_key_response.go
+++ b/api/v2/datadog/model_partial_application_key_response.go
@@ -135,6 +135,13 @@ func (o *PartialApplicationKeyResponse) UnmarshalJSON(bytes []byte) (err error) 
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	o.Included = all.Included
 	return nil

--- a/api/v2/datadog/model_permission.go
+++ b/api/v2/datadog/model_permission.go
@@ -184,6 +184,13 @@ func (o *Permission) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_process_summaries_meta.go
+++ b/api/v2/datadog/model_process_summaries_meta.go
@@ -97,6 +97,13 @@ func (o *ProcessSummariesMeta) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	return nil
 }

--- a/api/v2/datadog/model_process_summaries_response.go
+++ b/api/v2/datadog/model_process_summaries_response.go
@@ -136,6 +136,13 @@ func (o *ProcessSummariesResponse) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Data = all.Data
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v2/datadog/model_process_summary.go
+++ b/api/v2/datadog/model_process_summary.go
@@ -185,6 +185,13 @@ func (o *ProcessSummary) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_relationship_to_incident_postmortem.go
+++ b/api/v2/datadog/model_relationship_to_incident_postmortem.go
@@ -98,6 +98,13 @@ func (o *RelationshipToIncidentPostmortem) UnmarshalJSON(bytes []byte) (err erro
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_relationship_to_organization.go
+++ b/api/v2/datadog/model_relationship_to_organization.go
@@ -98,6 +98,13 @@ func (o *RelationshipToOrganization) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_relationship_to_permission.go
+++ b/api/v2/datadog/model_relationship_to_permission.go
@@ -97,6 +97,13 @@ func (o *RelationshipToPermission) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_relationship_to_role.go
+++ b/api/v2/datadog/model_relationship_to_role.go
@@ -97,6 +97,13 @@ func (o *RelationshipToRole) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_relationship_to_saml_assertion_attribute.go
+++ b/api/v2/datadog/model_relationship_to_saml_assertion_attribute.go
@@ -98,6 +98,13 @@ func (o *RelationshipToSAMLAssertionAttribute) UnmarshalJSON(bytes []byte) (err 
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_relationship_to_user.go
+++ b/api/v2/datadog/model_relationship_to_user.go
@@ -98,6 +98,13 @@ func (o *RelationshipToUser) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_response_meta_attributes.go
+++ b/api/v2/datadog/model_response_meta_attributes.go
@@ -97,6 +97,13 @@ func (o *ResponseMetaAttributes) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	return nil
 }

--- a/api/v2/datadog/model_role.go
+++ b/api/v2/datadog/model_role.go
@@ -222,8 +222,22 @@ func (o *Role) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_role_clone.go
+++ b/api/v2/datadog/model_role_clone.go
@@ -140,6 +140,13 @@ func (o *RoleClone) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_role_clone_request.go
+++ b/api/v2/datadog/model_role_clone_request.go
@@ -98,6 +98,13 @@ func (o *RoleCloneRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_role_create_data.go
+++ b/api/v2/datadog/model_role_create_data.go
@@ -186,7 +186,21 @@ func (o *RoleCreateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_role_create_request.go
+++ b/api/v2/datadog/model_role_create_request.go
@@ -98,6 +98,13 @@ func (o *RoleCreateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_role_create_response.go
+++ b/api/v2/datadog/model_role_create_response.go
@@ -97,6 +97,13 @@ func (o *RoleCreateResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_role_create_response_data.go
+++ b/api/v2/datadog/model_role_create_response_data.go
@@ -222,8 +222,22 @@ func (o *RoleCreateResponseData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_role_relationships.go
+++ b/api/v2/datadog/model_role_relationships.go
@@ -135,7 +135,21 @@ func (o *RoleRelationships) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Permissions != nil && all.Permissions.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Permissions = all.Permissions
+	if all.Users != nil && all.Users.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Users = all.Users
 	return nil
 }

--- a/api/v2/datadog/model_role_response.go
+++ b/api/v2/datadog/model_role_response.go
@@ -97,6 +97,13 @@ func (o *RoleResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_role_response_relationships.go
+++ b/api/v2/datadog/model_role_response_relationships.go
@@ -97,6 +97,13 @@ func (o *RoleResponseRelationships) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Permissions != nil && all.Permissions.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Permissions = all.Permissions
 	return nil
 }

--- a/api/v2/datadog/model_role_update_data.go
+++ b/api/v2/datadog/model_role_update_data.go
@@ -172,6 +172,13 @@ func (o *RoleUpdateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_role_update_request.go
+++ b/api/v2/datadog/model_role_update_request.go
@@ -98,6 +98,13 @@ func (o *RoleUpdateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_role_update_response.go
+++ b/api/v2/datadog/model_role_update_response.go
@@ -97,6 +97,13 @@ func (o *RoleUpdateResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_role_update_response_data.go
+++ b/api/v2/datadog/model_role_update_response_data.go
@@ -222,8 +222,22 @@ func (o *RoleUpdateResponseData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_roles_response.go
+++ b/api/v2/datadog/model_roles_response.go
@@ -136,6 +136,13 @@ func (o *RolesResponse) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Data = all.Data
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v2/datadog/model_rum_aggregate_request.go
+++ b/api/v2/datadog/model_rum_aggregate_request.go
@@ -251,9 +251,30 @@ func (o *RUMAggregateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Compute = all.Compute
+	if all.Filter != nil && all.Filter.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Filter = all.Filter
 	o.GroupBy = all.GroupBy
+	if all.Options != nil && all.Options.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Options = all.Options
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	return nil
 }

--- a/api/v2/datadog/model_rum_analytics_aggregate_response.go
+++ b/api/v2/datadog/model_rum_analytics_aggregate_response.go
@@ -173,8 +173,29 @@ func (o *RUMAnalyticsAggregateResponse) UnmarshalJSON(bytes []byte) (err error) 
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
+	if all.Links != nil && all.Links.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Links = all.Links
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v2/datadog/model_rum_event.go
+++ b/api/v2/datadog/model_rum_event.go
@@ -185,6 +185,13 @@ func (o *RUMEvent) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_rum_events_response.go
+++ b/api/v2/datadog/model_rum_events_response.go
@@ -174,7 +174,21 @@ func (o *RUMEventsResponse) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Data = all.Data
+	if all.Links != nil && all.Links.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Links = all.Links
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v2/datadog/model_rum_group_by.go
+++ b/api/v2/datadog/model_rum_group_by.go
@@ -294,9 +294,23 @@ func (o *RUMGroupBy) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Facet = all.Facet
+	if all.Histogram != nil && all.Histogram.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Histogram = all.Histogram
 	o.Limit = all.Limit
 	o.Missing = all.Missing
+	if all.Sort != nil && all.Sort.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Sort = all.Sort
 	o.Total = all.Total
 	return nil

--- a/api/v2/datadog/model_rum_response_metadata.go
+++ b/api/v2/datadog/model_rum_response_metadata.go
@@ -259,6 +259,13 @@ func (o *RUMResponseMetadata) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Elapsed = all.Elapsed
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	o.RequestId = all.RequestId
 	o.Status = all.Status

--- a/api/v2/datadog/model_rum_search_events_request.go
+++ b/api/v2/datadog/model_rum_search_events_request.go
@@ -220,8 +220,29 @@ func (o *RUMSearchEventsRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Filter != nil && all.Filter.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Filter = all.Filter
+	if all.Options != nil && all.Options.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Options = all.Options
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	o.Sort = all.Sort
 	return nil

--- a/api/v2/datadog/model_saml_assertion_attribute.go
+++ b/api/v2/datadog/model_saml_assertion_attribute.go
@@ -178,6 +178,13 @@ func (o *SAMLAssertionAttribute) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_security_filter.go
+++ b/api/v2/datadog/model_security_filter.go
@@ -185,6 +185,13 @@ func (o *SecurityFilter) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_security_filter_create_data.go
+++ b/api/v2/datadog/model_security_filter_create_data.go
@@ -140,6 +140,13 @@ func (o *SecurityFilterCreateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_security_filter_create_request.go
+++ b/api/v2/datadog/model_security_filter_create_request.go
@@ -98,6 +98,13 @@ func (o *SecurityFilterCreateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_security_filter_response.go
+++ b/api/v2/datadog/model_security_filter_response.go
@@ -135,7 +135,21 @@ func (o *SecurityFilterResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v2/datadog/model_security_filter_update_data.go
+++ b/api/v2/datadog/model_security_filter_update_data.go
@@ -140,6 +140,13 @@ func (o *SecurityFilterUpdateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_security_filter_update_request.go
+++ b/api/v2/datadog/model_security_filter_update_request.go
@@ -98,6 +98,13 @@ func (o *SecurityFilterUpdateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_security_filters_response.go
+++ b/api/v2/datadog/model_security_filters_response.go
@@ -136,6 +136,13 @@ func (o *SecurityFiltersResponse) UnmarshalJSON(bytes []byte) (err error) {
 		return nil
 	}
 	o.Data = all.Data
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v2/datadog/model_security_monitoring_list_rules_response.go
+++ b/api/v2/datadog/model_security_monitoring_list_rules_response.go
@@ -136,6 +136,13 @@ func (o *SecurityMonitoringListRulesResponse) UnmarshalJSON(bytes []byte) (err e
 		return nil
 	}
 	o.Data = all.Data
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v2/datadog/model_security_monitoring_rule_create_payload.go
+++ b/api/v2/datadog/model_security_monitoring_rule_create_payload.go
@@ -424,6 +424,13 @@ func (o *SecurityMonitoringRuleCreatePayload) UnmarshalJSON(bytes []byte) (err e
 	o.IsEnabled = all.IsEnabled
 	o.Message = all.Message
 	o.Name = all.Name
+	if all.Options.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Options = all.Options
 	o.Queries = all.Queries
 	o.Tags = all.Tags

--- a/api/v2/datadog/model_security_monitoring_rule_options.go
+++ b/api/v2/datadog/model_security_monitoring_rule_options.go
@@ -324,9 +324,23 @@ func (o *SecurityMonitoringRuleOptions) UnmarshalJSON(bytes []byte) (err error) 
 	}
 	o.DetectionMethod = all.DetectionMethod
 	o.EvaluationWindow = all.EvaluationWindow
+	if all.ImpossibleTravelOptions != nil && all.ImpossibleTravelOptions.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.ImpossibleTravelOptions = all.ImpossibleTravelOptions
 	o.KeepAlive = all.KeepAlive
 	o.MaxSignalDuration = all.MaxSignalDuration
+	if all.NewValueOptions != nil && all.NewValueOptions.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.NewValueOptions = all.NewValueOptions
 	return nil
 }

--- a/api/v2/datadog/model_security_monitoring_rule_response.go
+++ b/api/v2/datadog/model_security_monitoring_rule_response.go
@@ -724,6 +724,13 @@ func (o *SecurityMonitoringRuleResponse) UnmarshalJSON(bytes []byte) (err error)
 	o.IsEnabled = all.IsEnabled
 	o.Message = all.Message
 	o.Name = all.Name
+	if all.Options != nil && all.Options.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Options = all.Options
 	o.Queries = all.Queries
 	o.Tags = all.Tags

--- a/api/v2/datadog/model_security_monitoring_rule_update_payload.go
+++ b/api/v2/datadog/model_security_monitoring_rule_update_payload.go
@@ -445,6 +445,13 @@ func (o *SecurityMonitoringRuleUpdatePayload) UnmarshalJSON(bytes []byte) (err e
 	o.IsEnabled = all.IsEnabled
 	o.Message = all.Message
 	o.Name = all.Name
+	if all.Options != nil && all.Options.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Options = all.Options
 	o.Queries = all.Queries
 	o.Tags = all.Tags

--- a/api/v2/datadog/model_security_monitoring_signal.go
+++ b/api/v2/datadog/model_security_monitoring_signal.go
@@ -186,6 +186,13 @@ func (o *SecurityMonitoringSignal) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_security_monitoring_signal_list_request.go
+++ b/api/v2/datadog/model_security_monitoring_signal_list_request.go
@@ -181,7 +181,21 @@ func (o *SecurityMonitoringSignalListRequest) UnmarshalJSON(bytes []byte) (err e
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Filter != nil && all.Filter.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Filter = all.Filter
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	o.Sort = all.Sort
 	return nil

--- a/api/v2/datadog/model_security_monitoring_signals_list_response.go
+++ b/api/v2/datadog/model_security_monitoring_signals_list_response.go
@@ -175,7 +175,21 @@ func (o *SecurityMonitoringSignalsListResponse) UnmarshalJSON(bytes []byte) (err
 		return nil
 	}
 	o.Data = all.Data
+	if all.Links != nil && all.Links.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Links = all.Links
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/api/v2/datadog/model_security_monitoring_signals_list_response_meta.go
+++ b/api/v2/datadog/model_security_monitoring_signals_list_response_meta.go
@@ -97,6 +97,13 @@ func (o *SecurityMonitoringSignalsListResponseMeta) UnmarshalJSON(bytes []byte) 
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Page != nil && all.Page.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Page = all.Page
 	return nil
 }

--- a/api/v2/datadog/model_service_account_create_data.go
+++ b/api/v2/datadog/model_service_account_create_data.go
@@ -178,7 +178,21 @@ func (o *ServiceAccountCreateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_service_account_create_request.go
+++ b/api/v2/datadog/model_service_account_create_request.go
@@ -98,6 +98,13 @@ func (o *ServiceAccountCreateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_user.go
+++ b/api/v2/datadog/model_user.go
@@ -223,8 +223,22 @@ func (o *User) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_user_create_data.go
+++ b/api/v2/datadog/model_user_create_data.go
@@ -178,7 +178,21 @@ func (o *UserCreateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
+	if all.Relationships != nil && all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_user_create_request.go
+++ b/api/v2/datadog/model_user_create_request.go
@@ -98,6 +98,13 @@ func (o *UserCreateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_user_invitation_data.go
+++ b/api/v2/datadog/model_user_invitation_data.go
@@ -140,6 +140,13 @@ func (o *UserInvitationData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Relationships.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Relationships = all.Relationships
 	o.Type = all.Type
 	return nil

--- a/api/v2/datadog/model_user_invitation_relationships.go
+++ b/api/v2/datadog/model_user_invitation_relationships.go
@@ -98,6 +98,13 @@ func (o *UserInvitationRelationships) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.User.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.User = all.User
 	return nil
 }

--- a/api/v2/datadog/model_user_invitation_response.go
+++ b/api/v2/datadog/model_user_invitation_response.go
@@ -97,6 +97,13 @@ func (o *UserInvitationResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_user_invitation_response_data.go
+++ b/api/v2/datadog/model_user_invitation_response_data.go
@@ -185,6 +185,13 @@ func (o *UserInvitationResponseData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes != nil && all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_user_relationships.go
+++ b/api/v2/datadog/model_user_relationships.go
@@ -97,6 +97,13 @@ func (o *UserRelationships) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Roles != nil && all.Roles.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Roles = all.Roles
 	return nil
 }

--- a/api/v2/datadog/model_user_response.go
+++ b/api/v2/datadog/model_user_response.go
@@ -135,6 +135,13 @@ func (o *UserResponse) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data != nil && all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	o.Included = all.Included
 	return nil

--- a/api/v2/datadog/model_user_response_relationships.go
+++ b/api/v2/datadog/model_user_response_relationships.go
@@ -211,9 +211,37 @@ func (o *UserResponseRelationships) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Org != nil && all.Org.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Org = all.Org
+	if all.OtherOrgs != nil && all.OtherOrgs.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.OtherOrgs = all.OtherOrgs
+	if all.OtherUsers != nil && all.OtherUsers.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.OtherUsers = all.OtherUsers
+	if all.Roles != nil && all.Roles.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Roles = all.Roles
 	return nil
 }

--- a/api/v2/datadog/model_user_update_data.go
+++ b/api/v2/datadog/model_user_update_data.go
@@ -172,6 +172,13 @@ func (o *UserUpdateData) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Attributes.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Attributes = all.Attributes
 	o.Id = all.Id
 	o.Type = all.Type

--- a/api/v2/datadog/model_user_update_request.go
+++ b/api/v2/datadog/model_user_update_request.go
@@ -98,6 +98,13 @@ func (o *UserUpdateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		o.UnparsedObject = raw
 		return nil
 	}
+	if all.Data.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Data = all.Data
 	return nil
 }

--- a/api/v2/datadog/model_users_response.go
+++ b/api/v2/datadog/model_users_response.go
@@ -175,6 +175,13 @@ func (o *UsersResponse) UnmarshalJSON(bytes []byte) (err error) {
 	}
 	o.Data = all.Data
 	o.Included = all.Included
+	if all.Meta != nil && all.Meta.UnparsedObject != nil && o.UnparsedObject == nil {
+		err = json.Unmarshal(bytes, &raw)
+		if err != nil {
+			return err
+		}
+		o.UnparsedObject = raw
+	}
 	o.Meta = all.Meta
 	return nil
 }

--- a/tests/api/deserialization_test.go
+++ b/tests/api/deserialization_test.go
@@ -311,9 +311,9 @@ func TestDeserializationUnkownNestedEnum(t *testing.T) {
 	resp, httpresp, err := testV1.Client(ctx).SyntheticsApi.GetAPITest(ctx, "public_id")
 	assert.Nil(err)
 	assert.Equal(299, httpresp.StatusCode)
-	// Root object is properly deserialized
-	assert.Nil(resp.UnparsedObject)
-	assert.Nil(resp.Config.UnparsedObject)
+	// UnparsedObject is propagated up
+	assert.NotNil(resp.UnparsedObject)
+	assert.NotNil(resp.Config.UnparsedObject)
 	// Direct parent of invalid enum is unparsed
 	assert.NotNil(resp.Config.Request.UnparsedObject)
 	assert.Equal("A non existent method", resp.Config.Request.UnparsedObject["method"])


### PR DESCRIPTION
To parse oneOf properly we need to propagate it to parent resources.