### PR TITLE
Fix required nullable fields

### DIFF
--- a/.generator/src/generator/templates/model_simple.j2
+++ b/.generator/src/generator/templates/model_simple.j2
@@ -448,7 +448,7 @@ func (o *{{ name }}) UnmarshalJSON(bytes []byte) (err error) {
 	{%- if loop.first %}
 	required := struct {
 	{%- endif %}
-		{{ propertyName }} *{{ dataType }} `json:"{{ attr }}"`
+		{{ propertyName }} {% if not spec.nullable %}*{% endif %}{{ dataType }} `json:"{{ attr }}"`
 	{%- if loop.last %}
 	}{}
 	{%- endif %}
@@ -469,7 +469,11 @@ func (o *{{ name }}) UnmarshalJSON(bytes []byte) (err error) {
 		return err
 	}
 	{%- endif %}
+	{%- if not spec.nullable %}
 	if required.{{ propertyName }} == nil {
+	{%- else %}
+	if !required.{{ propertyName }}.IsSet() {
+	{%- endif %}
 		return fmt.Errorf("Required field {{ attr }} missing")
 	}
 	{%- endfor %}

--- a/api/v2/datadog/model_logs_archive_attributes.go
+++ b/api/v2/datadog/model_logs_archive_attributes.go
@@ -249,9 +249,9 @@ func (o LogsArchiveAttributes) MarshalJSON() ([]byte, error) {
 func (o *LogsArchiveAttributes) UnmarshalJSON(bytes []byte) (err error) {
 	raw := map[string]interface{}{}
 	required := struct {
-		Destination *NullableLogsArchiveDestination `json:"destination"`
-		Name        *string                         `json:"name"`
-		Query       *string                         `json:"query"`
+		Destination NullableLogsArchiveDestination `json:"destination"`
+		Name        *string                        `json:"name"`
+		Query       *string                        `json:"query"`
 	}{}
 	all := struct {
 		Destination     NullableLogsArchiveDestination `json:"destination"`
@@ -265,7 +265,7 @@ func (o *LogsArchiveAttributes) UnmarshalJSON(bytes []byte) (err error) {
 	if err != nil {
 		return err
 	}
-	if required.Destination == nil {
+	if !required.Destination.IsSet() {
 		return fmt.Errorf("Required field destination missing")
 	}
 	if required.Name == nil {

--- a/api/v2/datadog/model_nullable_relationship_to_user.go
+++ b/api/v2/datadog/model_nullable_relationship_to_user.go
@@ -79,7 +79,7 @@ func (o NullableRelationshipToUser) MarshalJSON() ([]byte, error) {
 func (o *NullableRelationshipToUser) UnmarshalJSON(bytes []byte) (err error) {
 	raw := map[string]interface{}{}
 	required := struct {
-		Data *NullableNullableRelationshipToUserData `json:"data"`
+		Data NullableNullableRelationshipToUserData `json:"data"`
 	}{}
 	all := struct {
 		Data NullableNullableRelationshipToUserData `json:"data"`
@@ -88,7 +88,7 @@ func (o *NullableRelationshipToUser) UnmarshalJSON(bytes []byte) (err error) {
 	if err != nil {
 		return err
 	}
-	if required.Data == nil {
+	if !required.Data.IsSet() {
 		return fmt.Errorf("Required field data missing")
 	}
 	err = json.Unmarshal(bytes, &all)


### PR DESCRIPTION
When go deserializes null to pointer, it skips custom UnmarshalJSON
method, thus breaking when the check when those fields are required.
Fortunately we only have 2 cases of this, but this fixes it.