### PR TITLE
Fix json.Marshal for aggregate timeseries response

### DIFF
--- a/api/v2/datadog/model_logs_aggregate_bucket_value_timeseries.go
+++ b/api/v2/datadog/model_logs_aggregate_bucket_value_timeseries.go
@@ -36,11 +36,10 @@ func NewLogsAggregateBucketValueTimeseriesWithDefaults() *LogsAggregateBucketVal
 }
 
 func (o LogsAggregateBucketValueTimeseries) MarshalJSON() ([]byte, error) {
-	toSerialize := make([]interface{}, len(o.Items))
 	if o.UnparsedObject != nil {
 		return json.Marshal(o.UnparsedObject)
 	}
-	return json.Marshal(toSerialize)
+	return json.Marshal(o.Items)
 }
 
 func (o *LogsAggregateBucketValueTimeseries) UnmarshalJSON(bytes []byte) (err error) {


### PR DESCRIPTION
<!--
** Requirements for Contributing to this repository **

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?
json.Marshal for aggregate log timeseries responses will always return null values.  This change fixes the json marshal to correctly return the values for the timeseries.

What inspired you to submit this pull request?
I need to query the API for aggregated logs and the values for the timeseries are sort of important.

Link to the issue describing the bug that you're fixing.
Fixes https://github.com/DataDog/datadog-api-client-go/issues/1505

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
