### PR TITLE
Allow compilation without cgo

### DIFF
--- a/.generator/src/generator/cli.py
+++ b/.generator/src/generator/cli.py
@@ -70,6 +70,8 @@ def cli(input, output):
         "client.go": env.get_template("client.j2"),
         "configuration.go": env.get_template("configuration.j2"),
         "utils.go": env.get_template("utils.j2"),
+        "zstd.go": env.get_template("zstd.j2"),
+        "no_zstd.go": env.get_template("no_zstd.j2"),
     }
 
     apis = openapi.apis(spec)

--- a/.generator/src/generator/templates/client.j2
+++ b/.generator/src/generator/templates/client.j2
@@ -26,7 +26,6 @@ import (
 	"unicode/utf8"
 
 	"golang.org/x/oauth2"
-	"github.com/DataDog/zstd"
 )
 
 var (
@@ -214,7 +213,7 @@ func (c *APIClient) PrepareRequest(
 	headerParams map[string]string,
 	queryParams url.Values,
 	formParams url.Values,
-        formFile *FormFile) (localVarRequest *http.Request, err error) {
+	formFile *FormFile) (localVarRequest *http.Request, err error) {
 
 	var body *bytes.Buffer
 
@@ -333,15 +332,10 @@ func (c *APIClient) PrepareRequest(
 			}
 			body = &buf
 		} else if headerParams["Content-Encoding"] == "zstd1" {
-			var buf bytes.Buffer
-			compressor := zstd.NewWriter(&buf)
-			if _, err = compressor.Write(body.Bytes()); err != nil {
+			body, err = compressZstd(body.Bytes())
+			if err != nil {
 				return nil, err
 			}
-			if err = compressor.Close(); err != nil {
-				return nil, err
-			}
-			body = &buf
 		}
 		headerParams["Content-Length"] = fmt.Sprintf("%d", body.Len())
 		localVarRequest, err = http.NewRequest(method, url.String(), body)

--- a/.generator/src/generator/templates/no_zstd.j2
+++ b/.generator/src/generator/templates/no_zstd.j2
@@ -1,0 +1,13 @@
+{% include "partial_header.j2" %}
+//go:build !cgo
+package {{ package_name }}
+
+import (
+	"bytes"
+	"errors"
+)
+
+func compressZstd(body []byte) (*bytes.Buffer, error) {
+	return nil, errors.New("zstd not supported")
+}
+

--- a/.generator/src/generator/templates/zstd.j2
+++ b/.generator/src/generator/templates/zstd.j2
@@ -1,0 +1,20 @@
+{% include "partial_header.j2" %}
+//go:build cgo
+package {{ package_name }}
+
+import (
+	"bytes"
+	"github.com/DataDog/zstd"
+)
+
+func compressZstd(body []byte) (*bytes.Buffer, error) {
+	var buf bytes.Buffer
+	compressor := zstd.NewWriter(&buf)
+	if _, err = compressor.Write(body); err != nil {
+		return nil, err
+	}
+	if err = compressor.Close(); err != nil {
+		return nil, err
+	}
+	return &buf, nil
+}

--- a/api/v1/datadog/client.go
+++ b/api/v1/datadog/client.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/zstd"
 	"golang.org/x/oauth2"
 )
 
@@ -419,15 +418,10 @@ func (c *APIClient) PrepareRequest(
 			}
 			body = &buf
 		} else if headerParams["Content-Encoding"] == "zstd1" {
-			var buf bytes.Buffer
-			compressor := zstd.NewWriter(&buf)
-			if _, err = compressor.Write(body.Bytes()); err != nil {
+			body, err = compressZstd(body.Bytes())
+			if err != nil {
 				return nil, err
 			}
-			if err = compressor.Close(); err != nil {
-				return nil, err
-			}
-			body = &buf
 		}
 		headerParams["Content-Length"] = fmt.Sprintf("%d", body.Len())
 		localVarRequest, err = http.NewRequest(method, url.String(), body)

--- a/api/v1/datadog/no_zstd.go
+++ b/api/v1/datadog/no_zstd.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+//go:build !cgo
+
+package datadog
+
+import (
+	"bytes"
+	"errors"
+)
+
+func compressZstd(body []byte) (*bytes.Buffer, error) {
+	return nil, errors.New("zstd not supported")
+}

--- a/api/v1/datadog/zstd.go
+++ b/api/v1/datadog/zstd.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+//go:build cgo
+
+package datadog
+
+import (
+	"bytes"
+
+	"github.com/DataDog/zstd"
+)
+
+func compressZstd(body []byte) (*bytes.Buffer, error) {
+	var buf bytes.Buffer
+	compressor := zstd.NewWriter(&buf)
+	if _, err = compressor.Write(body); err != nil {
+		return nil, err
+	}
+	if err = compressor.Close(); err != nil {
+		return nil, err
+	}
+	return &buf, nil
+}

--- a/api/v2/datadog/client.go
+++ b/api/v2/datadog/client.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/zstd"
 	"golang.org/x/oauth2"
 )
 
@@ -389,15 +388,10 @@ func (c *APIClient) PrepareRequest(
 			}
 			body = &buf
 		} else if headerParams["Content-Encoding"] == "zstd1" {
-			var buf bytes.Buffer
-			compressor := zstd.NewWriter(&buf)
-			if _, err = compressor.Write(body.Bytes()); err != nil {
+			body, err = compressZstd(body.Bytes())
+			if err != nil {
 				return nil, err
 			}
-			if err = compressor.Close(); err != nil {
-				return nil, err
-			}
-			body = &buf
 		}
 		headerParams["Content-Length"] = fmt.Sprintf("%d", body.Len())
 		localVarRequest, err = http.NewRequest(method, url.String(), body)

--- a/api/v2/datadog/no_zstd.go
+++ b/api/v2/datadog/no_zstd.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+//go:build !cgo
+
+package datadog
+
+import (
+	"bytes"
+	"errors"
+)
+
+func compressZstd(body []byte) (*bytes.Buffer, error) {
+	return nil, errors.New("zstd not supported")
+}

--- a/api/v2/datadog/zstd.go
+++ b/api/v2/datadog/zstd.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+//go:build cgo
+
+package datadog
+
+import (
+	"bytes"
+
+	"github.com/DataDog/zstd"
+)
+
+func compressZstd(body []byte) (*bytes.Buffer, error) {
+	var buf bytes.Buffer
+	compressor := zstd.NewWriter(&buf)
+	if _, err = compressor.Write(body); err != nil {
+		return nil, err
+	}
+	if err = compressor.Close(); err != nil {
+		return nil, err
+	}
+	return &buf, nil
+}


### PR DESCRIPTION
In some environments (like terraform) we can't build zstd.

Fixes #1582