### PR TITLE
Prepare for v2.0.1 release and retract `v2.0.0`+`v2.0.1`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,13 @@ module github.com/DataDog/datadog-api-client-go/v2
 
 go 1.17
 
+retract (
+	// Version used to retract v2.0.0 and v2.0.1. DO NOT USE.
+	v2.0.1
+	// Premature major version v2 release. DO NOT USE.
+	v2.0.0
+)
+
 require (
 	github.com/DataDog/zstd v1.5.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package client
 
 // Version used in User-Agent header.
-const Version = "2.0.1+dev"
+const Version = "2.0.1"


### PR DESCRIPTION
V2 of the library was released pre-maturely.

This PR retracts v2.0.0 and self (v2.0.1). This should resolve the latest tag to v1.16.0 when users try to pull.