### PR TITLE
Check statusCode before converting to json in undo

### DIFF
--- a/tests/scenarios/actions.go
+++ b/tests/scenarios/actions.go
@@ -270,14 +270,15 @@ func GetRequestsUndo(ctx gobdd.Context, version string, operationID string) (fun
 			if err != nil {
 				t.Fatalf("%v", err)
 			}
-			responseJSON, err := toJSON(response[0])
-			if err != nil {
-				t.Fatalf("%v", err)
-			}
 
 			// No object is created when it's a Bad Request
 			if responseStatusCode >= 400 {
 				return
+			}
+
+			responseJSON, err := toJSON(response[0])
+			if err != nil {
+				t.Fatalf("%v", err)
 			}
 
 			// enable unstable operation


### PR DESCRIPTION
This step needs to occur before trying to convert the result to json. Otherwise it will panic on oneOf responses where nil is returned when calling MarshallJSON. 

This is to unblock: https://github.com/DataDog/datadog-api-client-go/pull/1689