### PR TITLE
Pin staticcheck

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -24,7 +24,7 @@ fi
 # unfortunately there's no better way to fix this than change directory
 # this might get solved in Go 1.14: https://github.com/golang/go/issues/30515
 cd "$(mktemp -d)"
-GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@latest
+GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
 GO111MODULE=on go install gotest.tools/gotestsum@latest
 cd -
 


### PR DESCRIPTION
Latest `staticcheck` version requires go1.19