### PR TITLE
Fix some links in docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,8 +21,8 @@ jobs:
         run: |
           rm -rf examples
           rm -rf tests
-          go install github.com/therve/go/gopages@989785bb2fa287561022c17538cdcfe0d518efcf
-          gopages -source-link "https://github.com/DataDog/datadog-api-client-go/blob/master/{{.Path}}{{if .Line}}#L{{.Line}}{{end}}" -brand-description "Datadog API client for GO" -brand-title "Datadog" -base https://datadoghq.dev/datadog-api-client-go
+          go install github.com/johnstarich/go/gopages@latest
+          gopages -source-link "https://github.com/DataDog/datadog-api-client-go/blob/master/{{.Path}}{{if .Line}}#L{{.Line}}{{end}}" -brand-description "Datadog API client for GO" -brand-title "Datadog" -base /datadog-api-client-go
 
       - uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
Absolute links are broken currently, we need a path not a URL with a host. Also use upstream which should contain the changes made downstream.