### PR TITLE
Remove `GetActive()` assertion

### DIFF
--- a/tests/api/datadogV1/api_downtimes_test.go
+++ b/tests/api/datadogV1/api_downtimes_test.go
@@ -95,7 +95,6 @@ func TestDowntimeLifecycle(t *testing.T) {
 	if httpresp.StatusCode != 200 {
 		t.Errorf("Downtime %v should still exist: Response %s: %v", downtime.GetId(), err.(datadog.GenericOpenAPIError).Body(), err)
 	}
-	assert.False(fetchedDowntime.GetActive())
 	assert.True(fetchedDowntime.GetDisabled())
 }
 


### PR DESCRIPTION
It takes a bit of time for the field to be updated. For our use case, asserting that the downtime is disabled should be enough.