### PR TITLE
Fix `unparsedObject` deserialization for lists

### DIFF
--- a/.generator/src/generator/templates/model_simple.j2
+++ b/.generator/src/generator/templates/model_simple.j2
@@ -317,8 +317,33 @@ toSerialize["{{ attr }}"] = o.{{ propertyName }}
 
 // UnmarshalJSON deserializes the given payload.
 {%- if model.type == "array" %}
+{%- set isPrimitiveContainer = model.get("items")|is_primitive %}
 func (o *{{ name }}) UnmarshalJSON(bytes []byte) (err error) {
-	return json.Unmarshal(bytes, &o.Items)
+	if err = json.Unmarshal(bytes, &o.Items); err != nil {
+		err = json.Unmarshal(bytes, &o.UnparsedObject)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	{%- if not isPrimitiveContainer %}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				err = json.Unmarshal(bytes, &o.UnparsedObject)
+				if err != nil {
+					return err
+				}
+
+				break
+			}
+		}
+	}
+	{%- endif %}
+
+	return nil
 }
 
 {%- else %}

--- a/.generator/src/generator/templates/model_simple.j2
+++ b/.generator/src/generator/templates/model_simple.j2
@@ -320,11 +320,7 @@ toSerialize["{{ attr }}"] = o.{{ propertyName }}
 {%- set isPrimitiveContainer = model.get("items")|is_primitive %}
 func (o *{{ name }}) UnmarshalJSON(bytes []byte) (err error) {
 	if err = json.Unmarshal(bytes, &o.Items); err != nil {
-		err = json.Unmarshal(bytes, &o.UnparsedObject)
-		if err != nil {
-			return err
-		}
-		return nil
+		return json.Unmarshal(bytes, &o.UnparsedObject)
 	}
 
 	{%- if not isPrimitiveContainer %}

--- a/api/datadogV2/model_ci_app_aggregate_bucket_value_timeseries.go
+++ b/api/datadogV2/model_ci_app_aggregate_bucket_value_timeseries.go
@@ -47,5 +47,22 @@ func (o CIAppAggregateBucketValueTimeseries) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON deserializes the given payload.
 func (o *CIAppAggregateBucketValueTimeseries) UnmarshalJSON(bytes []byte) (err error) {
-	return json.Unmarshal(bytes, &o.Items)
+	if err = json.Unmarshal(bytes, &o.Items); err != nil {
+		return json.Unmarshal(bytes, &o.UnparsedObject)
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				err = json.Unmarshal(bytes, &o.UnparsedObject)
+				if err != nil {
+					return err
+				}
+
+				break
+			}
+		}
+	}
+
+	return nil
 }

--- a/api/datadogV2/model_logs_aggregate_bucket_value_timeseries.go
+++ b/api/datadogV2/model_logs_aggregate_bucket_value_timeseries.go
@@ -47,5 +47,22 @@ func (o LogsAggregateBucketValueTimeseries) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON deserializes the given payload.
 func (o *LogsAggregateBucketValueTimeseries) UnmarshalJSON(bytes []byte) (err error) {
-	return json.Unmarshal(bytes, &o.Items)
+	if err = json.Unmarshal(bytes, &o.Items); err != nil {
+		return json.Unmarshal(bytes, &o.UnparsedObject)
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				err = json.Unmarshal(bytes, &o.UnparsedObject)
+				if err != nil {
+					return err
+				}
+
+				break
+			}
+		}
+	}
+
+	return nil
 }

--- a/api/datadogV2/model_rum_aggregate_bucket_value_timeseries.go
+++ b/api/datadogV2/model_rum_aggregate_bucket_value_timeseries.go
@@ -47,5 +47,22 @@ func (o RUMAggregateBucketValueTimeseries) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON deserializes the given payload.
 func (o *RUMAggregateBucketValueTimeseries) UnmarshalJSON(bytes []byte) (err error) {
-	return json.Unmarshal(bytes, &o.Items)
+	if err = json.Unmarshal(bytes, &o.Items); err != nil {
+		return json.Unmarshal(bytes, &o.UnparsedObject)
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				err = json.Unmarshal(bytes, &o.UnparsedObject)
+				if err != nil {
+					return err
+				}
+
+				break
+			}
+		}
+	}
+
+	return nil
 }

--- a/api/datadogV2/model_spans_aggregate_bucket_value_timeseries.go
+++ b/api/datadogV2/model_spans_aggregate_bucket_value_timeseries.go
@@ -47,5 +47,22 @@ func (o SpansAggregateBucketValueTimeseries) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON deserializes the given payload.
 func (o *SpansAggregateBucketValueTimeseries) UnmarshalJSON(bytes []byte) (err error) {
-	return json.Unmarshal(bytes, &o.Items)
+	if err = json.Unmarshal(bytes, &o.Items); err != nil {
+		return json.Unmarshal(bytes, &o.UnparsedObject)
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				err = json.Unmarshal(bytes, &o.UnparsedObject)
+				if err != nil {
+					return err
+				}
+
+				break
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
We need to make sure unparsedObject gets propagated up as we do with non list models.