### PR TITLE
Skip TestMetrics test and unskip TestLogsIndexesUpdateErrors test

### DIFF
--- a/tests/api/datadogV1/api_logs_indexes_test.go
+++ b/tests/api/datadogV1/api_logs_indexes_test.go
@@ -285,7 +285,6 @@ func TestLogsIndexesGetErrors(t *testing.T) {
 }
 
 func TestLogsIndexesUpdateErrors(t *testing.T) {
-	t.Skip("Temporarily Skipping TestLogsIndexesUpdateErrors")
 	ctx, finish := tests.WithTestSpan(context.Background(), t)
 	defer finish()
 

--- a/tests/api/datadogV1/api_metrics_test.go
+++ b/tests/api/datadogV1/api_metrics_test.go
@@ -24,6 +24,9 @@ import (
 func TestMetrics(t *testing.T) {
 	ctx, finish := tests.WithTestSpan(context.Background(), t)
 	defer finish()
+	if tests.GetRecording() == tests.ModeIgnore {
+		t.Skipf("Slow test")
+	}
 	ctx, finish = WithRecorder(WithTestAuth(ctx), t)
 	defer finish()
 	assert := tests.Assert(ctx, t)


### PR DESCRIPTION
TestMetrics has an unreasonably long api delay to run such tests against.
Unskip TestLogsIndexesUpdateErrors because the backend error is gone