### PR TITLE
bump go version to 1.22

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
+          go-version: 1.22.x
 
     # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
+          go-version: 1.22.x
 
       - name: Build documentation
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
+          go-version: 1.22.x
           cache: true
           cache-dependency-path: tests/go.sum
       - name: Check examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
+          go-version: 1.22.x
       - id: pre_commit
         name: Run pre-commit
         if: github.event.action != 'closed' && github.event.pull_request.merged != true
@@ -81,7 +81,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.22.x, 1.23.x]
         go-build-tags: ["--tags=goccy_gojson", ""]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
+          go-version: 1.22.x
           cache: true
           cache-dependency-path: tests/go.sum
       - name: Run integration tests

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a Go API client for the [Datadog API](https://docs.data
 
 ## Requirements
 
-- Go 1.19+
+- Go 1.22+
 
 ## Layout
 

--- a/doc.go
+++ b/doc.go
@@ -4,7 +4,7 @@
 //
 // Requirements
 //
-// • Go 1.19+
+// • Go 1.22+
 //
 // Layout
 //

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-api-client-go/v2
 
-go 1.19
+go 1.22
 
 retract (
 	// Version used to retract v2.0.0 and v2.0.1. DO NOT USE.

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
 github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -24,7 +24,7 @@ fi
 # unfortunately there's no better way to fix this than change directory
 # this might get solved in Go 1.14: https://github.com/golang/go/issues/30515
 cd "$(mktemp -d)"
-GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
+GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@v0.5.0
 GO111MODULE=on go install gotest.tools/gotestsum@latest
 cd -
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -28,7 +28,7 @@ GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@v0.5.0
 GO111MODULE=on go install gotest.tools/gotestsum@latest
 cd -
 
-staticcheck ./api/...
+staticcheck -checks -SA1009 ./api/...
 go mod tidy
 go clean -testcache
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-api-client-go/v2/tests
 
-go 1.19
+go 1.22
 
 require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.14.0


### PR DESCRIPTION
[APITL-1075] — pins version of staticcheck and disables [S1009 check](https://staticcheck.dev/docs/checks#S1009)

[APITL-1075]: https://datadoghq.atlassian.net/browse/APITL-1075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ