### PR TITLE
added saml configurations model

### DIFF
--- a/api/datadogV2/model_saml_configurations.go
+++ b/api/datadogV2/model_saml_configurations.go
@@ -1,0 +1,103 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+package datadogV2
+
+import (
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+)
+
+// SamlConfigurations A JSON array of saml configurations.
+type SamlConfigurations struct {
+	// The content of metadata XML file.
+	IdpMetadata *UploadIdPMetadataOptionalParameters `json:"idp_metadata,omitempty"`
+	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
+	UnparsedObject       map[string]interface{} `json:"-"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// NewSamlConfigurations instantiates a new SamlConfigurations object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewSamlConfigurations() *SamlConfigurations {
+	this := SamlConfigurations{}
+	return &this
+}
+
+// NewSamlConfigurationsWithDefaults instantiates a new SamlConfigurations object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewSamlConfigurationsWithDefaults() *SamlConfigurations {
+	this := SamlConfigurations{}
+	return &this
+}
+
+// GetIdpMetadata returns the IdpMetadata field value if set, empty structure otherwise.
+func (o *SamlConfigurations) GetIdpMetadata() UploadIdPMetadataOptionalParameters {
+	if o == nil || o.IdpMetadata == nil {
+		var ret UploadIdPMetadataOptionalParameters
+		return ret
+	}
+	return *o.IdpMetadata
+}
+
+// GetIdpMetadataOk returns a tuple with the IdpMetadata field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SamlConfigurations) GetIdpMetadataOk() (*UploadIdPMetadataOptionalParameters, bool) {
+	if o == nil || o.IdpMetadata == nil {
+		return nil, false
+	}
+	return o.IdpMetadata, true
+}
+
+// HasIdpMetadata returns a boolean if a field has been set.
+func (o *SamlConfigurations) HasIdpMetadata() bool {
+	return o != nil && o.IdpMetadata != nil
+}
+
+// SetIdpMetadata gets a reference to the given structure and assigns it to the IdpMetadata field.
+func (o *SamlConfigurations) SetIdpMetadata(v *UploadIdPMetadataOptionalParameters) {
+	o.IdpMetadata = v
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o *SamlConfigurations) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.UnparsedObject != nil {
+		return datadog.Marshal(o.UnparsedObject)
+	}
+	if o.IdpMetadata != nil {
+		toSerialize["idp_metadata"] = o.IdpMetadata
+	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+	return datadog.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *SamlConfigurations) UnmarshalJSON(bytes []byte) (err error) {
+	all := struct {
+		IdpMetadata *UploadIdPMetadataOptionalParameters `json:"idp_metadata,omitempty"`
+	}{}
+	if err = datadog.Unmarshal(bytes, &all); err != nil {
+		return datadog.Unmarshal(bytes, &o.UnparsedObject)
+	}
+	additionalProperties := make(map[string]interface{})
+	if err = datadog.Unmarshal(bytes, &additionalProperties); err == nil {
+		datadog.DeleteKeys(additionalProperties, &[]string{"idp_metadata"})
+	} else {
+		return err
+	}
+
+	o.IdpMetadata = all.IdpMetadata
+
+	if len(additionalProperties) > 0 {
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--
** Requirements for Contributing to this repository **

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature."
If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

In the [Terraform Provider for Datadog](https://github.com/DataDog/terraform-provider-datadog) there is a missing feature for uploading SAML Metadata XML file. 
The endpoint for doing that already exists in Datadog API: [Upload IdP Metadata](https://docs.datadoghq.com/api/latest/organizations/#upload-idp-metadata). It is also implemented in this repo.

The endpoint references to version V2 and has only one subpath. That's why I decided to create a new structure called "Saml Configurations" -> like the last but one subpath in endpoint. For now the structure contains only IdpMetadata but using this approach will let others extend this feature in the future. 

The provided structure is created based on other models in `api/datadogV2` directory and is used in the [PR](https://github.com/DataDog/terraform-provider-datadog/pull/2652) in Terraform Provider for Datadog repo.

### Additional Notes

This PR should be merged first. Then I can reference a stable version of this repo in the go.mod in Terraform Provider for Datadog.

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
