### PR TITLE
sort enabled operations in examples

### DIFF
--- a/.generator/src/generator/templates/example.j2
+++ b/.generator/src/generator/templates/example.j2
@@ -54,7 +54,7 @@ func main() {
 {%- endif%}
 	ctx := datadog.NewDefaultContext(context.Background())
 	configuration := datadog.NewConfiguration()
-{%- for operation in context._enable_operations | sort %}
+{%- for operation in context._enable_operations|sort %}
 	configuration.SetUnstableOperationEnabled("{{ version }}.{{ operation }}", true)
 {%- endfor %}
 	apiClient := datadog.NewAPIClient(configuration)

--- a/.generator/src/generator/templates/example.j2
+++ b/.generator/src/generator/templates/example.j2
@@ -54,7 +54,7 @@ func main() {
 {%- endif%}
 	ctx := datadog.NewDefaultContext(context.Background())
 	configuration := datadog.NewConfiguration()
-{%- for operation in context._enable_operations %}
+{%- for operation in context._enable_operations | sort %}
 	configuration.SetUnstableOperationEnabled("{{ version }}.{{ operation }}", true)
 {%- endfor %}
 	apiClient := datadog.NewAPIClient(configuration)


### PR DESCRIPTION
`context._enable_operations` is a set and we want to make the order of enabled operations deterministic 