### PR TITLE
ci(workflows): fix use of create-github-app-token

### DIFF
--- a/.github/workflows/approved_status.yml
+++ b/.github/workflows/approved_status.yml
@@ -1,6 +1,6 @@
 name: Send PR Approval Status
 
-permissions: 
+permissions:
   contents: read
   pull-requests: write
 
@@ -27,9 +27,9 @@ jobs:
         id: get_token
         uses: tibdex/github-app-token@v1
         with:
-          app_id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private_key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
-          repository: DataDog/datadog-api-spec
+          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          repositories: DataDog/datadog-api-spec
       - name: Post PR review status check
         uses: DataDog/github-actions/post-review-status@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Run Tests
 
-permissions: 
+permissions:
   contents: read
 
 env:
@@ -127,9 +127,9 @@ jobs:
         id: get_token
         uses: tibdex/github-app-token@v1
         with:
-          app_id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private_key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
-          repository: DataDog/datadog-api-spec
+          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          repositories: DataDog/datadog-api-spec
       - name: Post status check
         uses: DataDog/github-actions/post-status-check@v2
         with:

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -46,9 +46,9 @@ jobs:
         id: get_token
         uses: tibdex/github-app-token@v1
         with:
-          app_id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private_key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
-          repository: DataDog/datadog-api-spec
+          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          repositories: DataDog/datadog-api-spec
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Post pending status check


### PR DESCRIPTION
### What does this PR do?

- fixes use of `create-github-app-token` with correct field name
