### PR TITLE
Remove depreceated is is_read_only from openapi

### DIFF
--- a/.generator/schemas/v1/openapi.yaml
+++ b/.generator/schemas/v1/openapi.yaml
@@ -1180,17 +1180,6 @@ components:
           example: 123-abc-456
           readOnly: true
           type: string
-        is_read_only:
-          default: false
-          deprecated: true
-          description: 'Whether this dashboard is read-only. If True, only the author
-            and admins can make changes to it.
-
-
-            This property is deprecated; please use the [Restriction Policies API](https://docs.datadoghq.com/api/latest/restriction-policies/)
-            instead to manage write authorization for individual dashboards.'
-          example: false
-          type: boolean
         layout_type:
           $ref: '#/components/schemas/DashboardLayoutType'
         modified_at:
@@ -1484,15 +1473,6 @@ components:
         id:
           description: Dashboard identifier.
           type: string
-        is_read_only:
-          deprecated: true
-          description: 'Whether this dashboard is read-only. If True, only the author
-            and admins can make changes to it.
-
-
-            This property is deprecated; please use the [Restriction Policies API](https://docs.datadoghq.com/api/latest/restriction-policies/)
-            instead to manage write authorization for individual dashboards.'
-          type: boolean
         layout_type:
           $ref: '#/components/schemas/DashboardLayoutType'
         modified_at:
@@ -5939,10 +5919,6 @@ components:
           type: string
         is_enabled:
           description: Whether or not the pipeline is enabled.
-          type: boolean
-        is_read_only:
-          description: Whether or not the pipeline can be edited.
-          readOnly: true
           type: boolean
         name:
           description: Name of the pipeline.

--- a/.generator/schemas/v2/openapi.yaml
+++ b/.generator/schemas/v2/openapi.yaml
@@ -9273,10 +9273,6 @@ components:
           description: Whether or not the dashboard is in the favorites.
           readOnly: true
           type: boolean
-        is_read_only:
-          description: Whether or not the dashboard is read only.
-          readOnly: true
-          type: boolean
         is_shared:
           description: Whether the dashboard is publicly shared or not.
           readOnly: true


### PR DESCRIPTION
### What does this PR do?
As stated by @matthew-parry-cc in https://github.com/DataDog/datadog-operator/issues/1707, the datadog-operator is broken due to the following problem: ` Message:               error creating dashboard: 400 Bad Request: {"errors":["The is_read_only attribute is no longer supported.                     https://docs.datadoghq.com/dashboards/guide/is-read-only-deprecation/"]}`

Since the announcement last month of [Dashboards API: Migrate from is_read_only](https://docs.datadoghq.com/dashboards/guide/is-read-only-deprecation/), the api is returning Bad Request when sending that option, even if set to false.

Maybe just removing all the is_read_only from all dashboard apis is too aggressive, but given that the change in the api returning a 400 is a breaking change, I think the only option is not to send the key at all.

### Additional Notes

Please, check that this is not too hardcore and if the problem is in the client side and that API is expected to return a 400 when sending is_read_only even if deprecated.

### Review checklist

Please check relevant items below:

- [X] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [ ] This PR does not rely on API client schema changes. <- I'm not sure how it should be done TBH. Is the rest of the code automatically generated after this change?
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
