### PR TITLE
set global headers earlier when preparing request

### DIFF
--- a/.generator/src/generator/templates/client.j2
+++ b/.generator/src/generator/templates/client.j2
@@ -232,6 +232,13 @@ func (c *APIClient) PrepareRequest(
 
 	var body *bytes.Buffer
 
+	// Apply default headers unless they are overridden
+	for header, value := range c.Cfg.DefaultHeader {
+		if _, exists := headerParams[header]; !exists {
+			headerParams[header] = value
+		}
+	}
+
 	// Detect postBody type and post.
 	if postBody != nil {
 		contentType := headerParams["Content-Type"]
@@ -399,10 +406,6 @@ func (c *APIClient) PrepareRequest(
 		if auth, ok := ctx.Value(ContextAccessToken).(string); ok {
 			localVarRequest.Header.Add("Authorization", "Bearer "+auth)
 		}
-	}
-
-	for header, value := range c.Cfg.DefaultHeader {
-		localVarRequest.Header.Add(header, value)
 	}
 
 	if !c.Cfg.Compress {

--- a/api/datadog/client.go
+++ b/api/datadog/client.go
@@ -232,6 +232,13 @@ func (c *APIClient) PrepareRequest(
 
 	var body *bytes.Buffer
 
+	// Apply default headers unless they are overridden
+	for header, value := range c.Cfg.DefaultHeader {
+		if _, exists := headerParams[header]; !exists {
+			headerParams[header] = value
+		}
+	}
+
 	// Detect postBody type and post.
 	if postBody != nil {
 		contentType := headerParams["Content-Type"]
@@ -399,10 +406,6 @@ func (c *APIClient) PrepareRequest(
 		if auth, ok := ctx.Value(ContextAccessToken).(string); ok {
 			localVarRequest.Header.Add("Authorization", "Bearer "+auth)
 		}
-	}
-
-	for header, value := range c.Cfg.DefaultHeader {
-		localVarRequest.Header.Add(header, value)
 	}
 
 	if !c.Cfg.Compress {


### PR DESCRIPTION
[AAWF-292](https://datadoghq.atlassian.net/browse/AAWF-292)

Applying default headers at the end of `PrepareRequest` means that encoding headers were not respected when set in the client configuration. This PR sets all of the headers in the configuration at the beginning of `PrepareRequest` unless they are overridden by the caller. 

[AAWF-292]: https://datadoghq.atlassian.net/browse/AAWF-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ