### PR TITLE
sanitize configuration keys correctly

### DIFF
--- a/.generator/src/generator/templates/configuration.j2
+++ b/.generator/src/generator/templates/configuration.j2
@@ -154,7 +154,7 @@ func NewConfiguration() *Configuration {
 			{%- for operation in path.values() %}
 			{%- for server in operation.servers %}
 			{%- if loop.first %}
-			"{{ version }}.{{ name | class_name }}.{{ operation.operationId }}": {
+			"{{ version }}.{{ operation.tags[0] | class_name }}.{{ operation.operationId }}": {
 			{%- endif %}
 				{{ server_configuration(server)|indent("\t"*4) }},
 			{%- if loop.last %}

--- a/.generator/src/generator/templates/configuration.j2
+++ b/.generator/src/generator/templates/configuration.j2
@@ -154,7 +154,7 @@ func NewConfiguration() *Configuration {
 			{%- for operation in path.values() %}
 			{%- for server in operation.servers %}
 			{%- if loop.first %}
-			"{{ version }}.{{ operation.tags[0].replace(" ", "") }}Api.{{ operation.operationId }}": {
+			"{{ version }}.{{ name | class_name }}.{{ operation.operationId }}": {
 			{%- endif %}
 				{{ server_configuration(server)|indent("\t"*4) }},
 			{%- if loop.last %}

--- a/api/datadog/configuration.go
+++ b/api/datadog/configuration.go
@@ -321,7 +321,7 @@ func NewConfiguration() *Configuration {
 					},
 				},
 			},
-			"v2.On-CallPagingApi.CreateOnCallPage": {
+			"v2.OnCallPagingApi.CreateOnCallPage": {
 				{
 					URL:         "https://{site}",
 					Description: "No description provided",
@@ -368,7 +368,7 @@ func NewConfiguration() *Configuration {
 					},
 				},
 			},
-			"v2.On-CallPagingApi.AcknowledgeOnCallPage": {
+			"v2.OnCallPagingApi.AcknowledgeOnCallPage": {
 				{
 					URL:         "https://{site}",
 					Description: "No description provided",
@@ -415,7 +415,7 @@ func NewConfiguration() *Configuration {
 					},
 				},
 			},
-			"v2.On-CallPagingApi.EscalateOnCallPage": {
+			"v2.OnCallPagingApi.EscalateOnCallPage": {
 				{
 					URL:         "https://{site}",
 					Description: "No description provided",
@@ -462,7 +462,7 @@ func NewConfiguration() *Configuration {
 					},
 				},
 			},
-			"v2.On-CallPagingApi.ResolveOnCallPage": {
+			"v2.OnCallPagingApi.ResolveOnCallPage": {
 				{
 					URL:         "https://{site}",
 					Description: "No description provided",


### PR DESCRIPTION
The api template uses class_name, but the config was not. This led to a divergence for On-Call Paging:

Usage: https://github.com/DataDog/datadog-api-client-go/blob/31a2b1a4757da7b06ba985bba77b512c5f45224d/api/datadogV2/api_on_call_paging.go#L89
Configuration: https://github.com/DataDog/datadog-api-client-go/blob/31a2b1a4757da7b06ba985bba77b512c5f45224d/api/datadog/configuration.go#L324

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
