### PR TITLE
add branch name as input in the reusable workflow

### DIFF
--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -3,6 +3,11 @@ name: Reusable Go Testing Workflow
 on:
   workflow_call:
     inputs:
+      target-branch:
+        description: 'Branch to checkout and test (defaults to the calling branch)'
+        required: false
+        type: string
+        default: ''
       enable-status-reporting:
         description: 'Whether to post status checks to datadog-api-spec repo'
         required: false
@@ -32,6 +37,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.target-branch || github.ref }}
       - name: Install Go
         uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
## Context

In the [previous PR](https://github.com/DataDog/datadog-api-client-go/pull/3317). I assumed that we could call the workflow from another repo on a dynamically chosen branch name. This is not correct so instead we add a input to choose the branch on which to run the workflow


## Changes

Add a optional input for the branch name. When defined checkout to this branch in the first step of the test workflow