### PR TITLE
force checkout to the client repo in the workflow

### DIFF
--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
+          repository: DataDog/datadog-api-client-go
           ref: ${{ inputs.target-branch || github.ref }}
       - name: Install Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
## Context

When calling a reusable workflow from another repo it runs in the context of the calling repository. This caused the job to fail in the spec repo because it tried to checkout to a branch on the spec repo that didn't exist

## Changes

Specify the repo to when checking out

## Test

See the CI of the [PR calling this workflow from the specification repository](https://github.com/DataDog/datadog-api-spec/pull/4340).