### PR TITLE
Configure our publish branch with only the latest commit

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,3 +37,5 @@ jobs:
           enable_jekyll: false
           # Only deploy if there were changes
           allow_empty_commit: false
+          # GH pages branch is getting super big, so we want to reduce it by creating an orphan branch
+          force_orphan: true


### PR DESCRIPTION
### What does this PR do?

Our gh-pages branch is getting quite big, which is slowing down clones that are not using shallow clone. Let's ensure the gh_pages only builds the latest reference, so we can clean up these later

### Additional Notes

Mirrors https://github.com/DataDog/datadog-api-client-typescript/pull/3529

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [ ] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.