### PR TITLE
Place Monitor HasName after GetName

### DIFF
--- a/api/datadogV1/model_monitor.go
+++ b/api/datadogV1/model_monitor.go
@@ -384,6 +384,11 @@ func (o *Monitor) GetName() string {
 	return *o.Name
 }
 
+// HasName returns a boolean if a field has been set.
+func (o *Monitor) HasName() bool {
+	return o != nil && o.Name != nil
+}
+
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Monitor) GetNameOk() (*string, bool) {
@@ -391,11 +396,6 @@ func (o *Monitor) GetNameOk() (*string, bool) {
 		return nil, false
 	}
 	return o.Name, true
-}
-
-// HasName returns a boolean if a field has been set.
-func (o *Monitor) HasName() bool {
-	return o != nil && o.Name != nil
 }
 
 // SetName gets a reference to the given string and assigns it to the Name field.


### PR DESCRIPTION
<!-- dd-meta {"pullId":"378ba46d-4cb4-4b0b-83e6-e0784a452eab","source":"chat","resourceId":"7f859d75-2fc8-4ad8-a5ab-fee2b1387a52","workflowId":"8de4bbe4-17a2-48b3-b199-58587a64f120","codeChangeId":"8de4bbe4-17a2-48b3-b199-58587a64f120","sourceType":"chat-mcp-proxy"} -->
<!-- code-gen-hotdog: abhinavpunj -->
### What does this PR do?

This PR updates the `Monitor` model accessor ordering to place `HasName()` immediately after `GetName()` in `api/datadogV1/model_monitor.go`, matching the requested method placement.

### Additional Notes

The existing `HasName` behavior is unchanged (`o != nil && o.Name != nil`); this change only repositions the method and keeps the implementation consistent.

### Review checklist

Please check relevant items below:

- [x] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.

### Changes

- Added `HasName() bool` directly after `GetName()` in `Monitor`.
- Removed the previous `HasName()` block from below `GetNameOk()` to avoid duplicate definitions while preserving behavior.

### Testing

- Ran `Format` tool (goimports/gofmt): no additional formatting changes required.
- Ran `Lint` tool: `go build ./api/datadogV1 && go vet ./api/datadogV1`.

### Related Issues

- None.

---

PR by Bits - [View session in Datadog](https://dd.datad0g.com/code/7f859d75-2fc8-4ad8-a5ab-fee2b1387a52)

Comment @datadog-staging to request changes