### PR TITLE
[TEST] Step 3 – Fix: Rename DashboardListDeleteItemsRequest to DashboardListRemoveItemsRequest + Terraform Go Repo Fix Linked

### DIFF
--- a/.generator/schemas/v2/openapi.yaml
+++ b/.generator/schemas/v2/openapi.yaml
@@ -19144,15 +19144,6 @@ components:
             $ref: "#/components/schemas/DashboardListItemResponse"
           type: array
       type: object
-    DashboardListDeleteItemsRequest:
-      description: Request containing a list of dashboards to delete.
-      properties:
-        dashboards:
-          description: List of dashboards to delete from the dashboard list.
-          items:
-            $ref: "#/components/schemas/DashboardListItemRequest"
-          type: array
-      type: object
     DashboardListDeleteItemsResponse:
       description: Response containing a list of deleted dashboards.
       properties:
@@ -19275,6 +19266,15 @@ components:
           type: integer
       required:
         - dashboards
+      type: object
+    DashboardListRemoveItemsRequest:
+      description: Request containing a list of dashboards to remove.
+      properties:
+        dashboards:
+          description: List of dashboards to delete from the dashboard list.
+          items:
+            $ref: "#/components/schemas/DashboardListItemRequest"
+          type: array
       type: object
     DashboardListUpdateItemsRequest:
       description: Request containing the list of dashboards to update to.
@@ -81673,7 +81673,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DashboardListDeleteItemsRequest"
+              $ref: "#/components/schemas/DashboardListRemoveItemsRequest"
         description: Dashboards to delete from the dashboard list.
         required: true
       responses:

--- a/.github/terraform-provider-pr
+++ b/.github/terraform-provider-pr
@@ -1,0 +1,1 @@
+https://github.com/DataDog/terraform-provider-datadog/pull/3660

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,35 @@ on:
       - master
 
 jobs:
+  cleanup_terraform_provider_pr:
+    name: Clean up terraform-provider-pr
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Get GitHub App token
+        id: get_token
+        uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 #v1.11.1
+        with:
+          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+      - name: Checkout master
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: master
+          token: ${{ steps.get_token.outputs.token }}
+      - name: Remove terraform-provider-pr file if present
+        run: |
+          if [ -f .github/terraform-provider-pr ]; then
+            git config user.name "${GIT_AUTHOR_NAME}"
+            git config user.email "${GIT_AUTHOR_EMAIL}"
+            git rm .github/terraform-provider-pr
+            git commit -m "Clean up .github/terraform-provider-pr after merge"
+            git push origin HEAD:master
+            echo "✅ Removed .github/terraform-provider-pr from master"
+          else
+            echo "ℹ️ No .github/terraform-provider-pr file to clean up"
+          fi
+
   create_release:
     name: Create release
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -8,7 +8,6 @@ on:
         required: false
         type: string
         default: ''
-      
     secrets:
       PIPELINE_GITHUB_APP_ID:
         required: false
@@ -38,6 +37,9 @@ jobs:
     uses: ./.github/workflows/reusable-go-test.yml
     with:
       target-branch: ${{ inputs.target-branch }}
+    secrets:
+      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
 
   examples:
     uses: ./.github/workflows/reusable-examples.yml

--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -9,6 +9,12 @@ on:
         type: string
         default: ''
 
+    secrets:
+      PIPELINE_GITHUB_APP_ID:
+        required: false
+      PIPELINE_GITHUB_APP_PRIVATE_KEY:
+        required: false
+
 jobs:
   test:
     strategy:
@@ -34,3 +40,120 @@ jobs:
         env:
           TESTARGS: ${{ matrix.go-build-tags }}
 
+  build-terraform-provider:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get GitHub App token
+        id: get_token
+        uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 #v1.11.1
+        with:
+          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          owner: DataDog
+
+      - name: Setup to use the GitHub token
+        run: |-
+          git config --global --add url."https://${APP_ID}:${APP_TOKEN}@github.com/".insteadOf "https://github.com/"
+        env:
+          APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+          APP_TOKEN: ${{ steps.get_token.outputs.token }}
+
+      - name: Checkout datadog-api-client-go
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: DataDog/datadog-api-client-go
+          ref: ${{ github.ref }}
+          token: ${{ steps.get_token.outputs.token }}
+          path: client-repo
+
+      - name: Detect linked terraform-provider-datadog PR
+        id: detect_tf_pr
+        run: |
+          # If a breaking Go client change requires terraform code changes, the author
+          # adds a .github/terraform-provider-pr file containing the full PR URL, e.g.
+          # https://github.com/DataDog/terraform-provider-datadog/pull/1234
+          # The file is safe to leave after merging — stale references to merged/closed
+          # PRs are automatically ignored and the build falls back to master.
+          if [ -f client-repo/.github/terraform-provider-pr ]; then
+            tf_pr_link=$(cat client-repo/.github/terraform-provider-pr | tr -d '[:space:]')
+            tf_pr_number=$(echo "$tf_pr_link" | grep -oE '[0-9]+$')
+            if [ -z "$tf_pr_number" ]; then
+              echo "❌ .github/terraform-provider-pr exists but could not extract a PR number from: ${tf_pr_link}"
+              echo "   Expected format: https://github.com/DataDog/terraform-provider-datadog/pull/<number>"
+              echo "branch=master" >> $GITHUB_OUTPUT
+            else
+              tf_state=$(gh pr view "$tf_pr_number" --repo DataDog/terraform-provider-datadog --json state --jq '.state')
+
+              if [ "$tf_state" = "OPEN" ]; then
+                tf_branch=$(gh pr view "$tf_pr_number" --repo DataDog/terraform-provider-datadog --json headRefName --jq '.headRefName')
+                echo "branch=${tf_branch}" >> $GITHUB_OUTPUT
+                echo "✅ Found .github/terraform-provider-pr → PR #${tf_pr_number} (branch: ${tf_branch})"
+              else
+                echo "branch=master" >> $GITHUB_OUTPUT
+                echo "ℹ️ .github/terraform-provider-pr references PR #${tf_pr_number} which is ${tf_state} — using master"
+              fi
+            fi
+          else
+            echo "branch=master" >> $GITHUB_OUTPUT
+            echo "ℹ️ No .github/terraform-provider-pr file found, using master"
+          fi
+        env:
+          GH_TOKEN: ${{ steps.get_token.outputs.token }}
+
+      - name: Checkout terraform-provider-datadog
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: DataDog/terraform-provider-datadog
+          ref: ${{ steps.detect_tf_pr.outputs.branch }}
+          token: ${{ steps.get_token.outputs.token }}
+
+      - name: Set up Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Resolve generated branch to commit SHA
+        id: resolve_sha
+        run: |
+          # go get rejects branch names with slashes (e.g. datadog-api-spec/generated/1234),
+          # so we resolve the branch to its commit SHA first.
+          COMMIT_SHA=$(gh api "repos/DataDog/datadog-api-client-go/commits/${GO_CLIENT_BRANCH}" --jq '.sha')
+          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ steps.get_token.outputs.token }}
+          GO_CLIENT_BRANCH: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Update datadog-api-client-go to generated commit
+        run: |
+          # GOPROXY=direct bypasses the module proxy, which won't have unreleased
+          # commits from the private datadog-api-client-go repo.
+          GOPROXY=direct go get "github.com/DataDog/datadog-api-client-go/v2@${COMMIT_SHA}"
+          go mod tidy
+        env:
+          COMMIT_SHA: ${{ steps.resolve_sha.outputs.commit_sha }}
+
+      - name: Build terraform provider
+        run: |
+          if ! go build ./...; then
+            echo ""
+            echo "🚨 BUILD FAILED"
+            echo "This Go client change breaks the terraform-provider-datadog build."
+            echo ""
+            if [ "${TF_BRANCH}" = "master" ]; then
+              echo "The build was tested against the terraform-provider-datadog 'master' branch."
+              echo ""
+              echo "To fix this:"
+              echo "  1. Create a PR on DataDog/terraform-provider-datadog with the necessary code changes"
+              echo "  2. Add a file '.github/terraform-provider-pr' to your datadog-api-client-go branch containing the full PR link"
+              echo "     e.g. https://github.com/DataDog/terraform-provider-datadog/pull/1234"
+              echo "  3. Commit and push — the check will re-run automatically"
+            else
+              echo "The build was tested against the terraform-provider-datadog branch '${TF_BRANCH}'."
+              echo "The linked PR also fails to build with the generated Go client — please fix it."
+            fi
+            exit 1
+          fi
+          echo ""
+          echo "✅ Build succeeded — terraform-provider-datadog builds correctly with the generated Go client."
+        env:
+          TF_BRANCH: ${{ steps.detect_tf_pr.outputs.branch }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
        !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')) ||
       github.event_name == 'schedule'
     uses: ./.github/workflows/reusable-go-test.yml
+    secrets:
+      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
 
   examples:
     if: >

--- a/api/datadogV2/api_dashboard_lists.go
+++ b/api/datadogV2/api_dashboard_lists.go
@@ -98,7 +98,7 @@ func (a *DashboardListsApi) CreateDashboardListItems(ctx _context.Context, dashb
 
 // DeleteDashboardListItems Delete items from a dashboard list.
 // Delete dashboards from an existing dashboard list.
-func (a *DashboardListsApi) DeleteDashboardListItems(ctx _context.Context, dashboardListId int64, body DashboardListDeleteItemsRequest) (DashboardListDeleteItemsResponse, *_nethttp.Response, error) {
+func (a *DashboardListsApi) DeleteDashboardListItems(ctx _context.Context, dashboardListId int64, body DashboardListRemoveItemsRequest) (DashboardListDeleteItemsResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod  = _nethttp.MethodDelete
 		localVarPostBody    interface{}

--- a/api/datadogV2/model_dashboard_list_remove_items_request.go
+++ b/api/datadogV2/model_dashboard_list_remove_items_request.go
@@ -8,8 +8,8 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 )
 
-// DashboardListDeleteItemsRequest Request containing a list of dashboards to delete.
-type DashboardListDeleteItemsRequest struct {
+// DashboardListRemoveItemsRequest Request containing a list of dashboards to remove.
+type DashboardListRemoveItemsRequest struct {
 	// List of dashboards to delete from the dashboard list.
 	Dashboards []DashboardListItemRequest `json:"dashboards,omitempty"`
 	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
@@ -17,25 +17,25 @@ type DashboardListDeleteItemsRequest struct {
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
-// NewDashboardListDeleteItemsRequest instantiates a new DashboardListDeleteItemsRequest object.
+// NewDashboardListRemoveItemsRequest instantiates a new DashboardListRemoveItemsRequest object.
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed.
-func NewDashboardListDeleteItemsRequest() *DashboardListDeleteItemsRequest {
-	this := DashboardListDeleteItemsRequest{}
+func NewDashboardListRemoveItemsRequest() *DashboardListRemoveItemsRequest {
+	this := DashboardListRemoveItemsRequest{}
 	return &this
 }
 
-// NewDashboardListDeleteItemsRequestWithDefaults instantiates a new DashboardListDeleteItemsRequest object.
+// NewDashboardListRemoveItemsRequestWithDefaults instantiates a new DashboardListRemoveItemsRequest object.
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set.
-func NewDashboardListDeleteItemsRequestWithDefaults() *DashboardListDeleteItemsRequest {
-	this := DashboardListDeleteItemsRequest{}
+func NewDashboardListRemoveItemsRequestWithDefaults() *DashboardListRemoveItemsRequest {
+	this := DashboardListRemoveItemsRequest{}
 	return &this
 }
 
 // GetDashboards returns the Dashboards field value if set, zero value otherwise.
-func (o *DashboardListDeleteItemsRequest) GetDashboards() []DashboardListItemRequest {
+func (o *DashboardListRemoveItemsRequest) GetDashboards() []DashboardListItemRequest {
 	if o == nil || o.Dashboards == nil {
 		var ret []DashboardListItemRequest
 		return ret
@@ -45,7 +45,7 @@ func (o *DashboardListDeleteItemsRequest) GetDashboards() []DashboardListItemReq
 
 // GetDashboardsOk returns a tuple with the Dashboards field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *DashboardListDeleteItemsRequest) GetDashboardsOk() (*[]DashboardListItemRequest, bool) {
+func (o *DashboardListRemoveItemsRequest) GetDashboardsOk() (*[]DashboardListItemRequest, bool) {
 	if o == nil || o.Dashboards == nil {
 		return nil, false
 	}
@@ -53,17 +53,17 @@ func (o *DashboardListDeleteItemsRequest) GetDashboardsOk() (*[]DashboardListIte
 }
 
 // HasDashboards returns a boolean if a field has been set.
-func (o *DashboardListDeleteItemsRequest) HasDashboards() bool {
+func (o *DashboardListRemoveItemsRequest) HasDashboards() bool {
 	return o != nil && o.Dashboards != nil
 }
 
 // SetDashboards gets a reference to the given []DashboardListItemRequest and assigns it to the Dashboards field.
-func (o *DashboardListDeleteItemsRequest) SetDashboards(v []DashboardListItemRequest) {
+func (o *DashboardListRemoveItemsRequest) SetDashboards(v []DashboardListItemRequest) {
 	o.Dashboards = v
 }
 
 // MarshalJSON serializes the struct using spec logic.
-func (o DashboardListDeleteItemsRequest) MarshalJSON() ([]byte, error) {
+func (o DashboardListRemoveItemsRequest) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.UnparsedObject != nil {
 		return datadog.Marshal(o.UnparsedObject)
@@ -79,7 +79,7 @@ func (o DashboardListDeleteItemsRequest) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON deserializes the given payload.
-func (o *DashboardListDeleteItemsRequest) UnmarshalJSON(bytes []byte) (err error) {
+func (o *DashboardListRemoveItemsRequest) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
 		Dashboards []DashboardListItemRequest `json:"dashboards,omitempty"`
 	}{}

--- a/examples/v2/dashboard-lists/DeleteDashboardListItems.go
+++ b/examples/v2/dashboard-lists/DeleteDashboardListItems.go
@@ -13,7 +13,7 @@ import (
 )
 
 func main() {
-	body := datadogV2.DashboardListDeleteItemsRequest{
+	body := datadogV2.DashboardListRemoveItemsRequest{
 		Dashboards: []datadogV2.DashboardListItemRequest{
 			{
 				Id:   "q5j-nti-fv6",

--- a/examples/v2/dashboard-lists/DeleteDashboardListItems_2656706656.go
+++ b/examples/v2/dashboard-lists/DeleteDashboardListItems_2656706656.go
@@ -20,7 +20,7 @@ func main() {
 	// there is a valid "dashboard" in the system
 	DashboardID := os.Getenv("DASHBOARD_ID")
 
-	body := datadogV2.DashboardListDeleteItemsRequest{
+	body := datadogV2.DashboardListRemoveItemsRequest{
 		Dashboards: []datadogV2.DashboardListItemRequest{
 			{
 				Id:   DashboardID,

--- a/examples/v2/dashboard-lists/DeleteDashboardListItems_3851624753.go
+++ b/examples/v2/dashboard-lists/DeleteDashboardListItems_3851624753.go
@@ -20,7 +20,7 @@ func main() {
 	// there is a valid "screenboard_dashboard" in the system
 	ScreenboardDashboardID := os.Getenv("SCREENBOARD_DASHBOARD_ID")
 
-	body := datadogV2.DashboardListDeleteItemsRequest{
+	body := datadogV2.DashboardListRemoveItemsRequest{
 		Dashboards: []datadogV2.DashboardListItemRequest{
 			{
 				Id:   ScreenboardDashboardID,


### PR DESCRIPTION
### What does this PR do?

Adds a `.github/terraform-provider-pr` file pointing to [DataDog/terraform-provider-datadog#3660](https://github.com/DataDog/terraform-provider-datadog/pull/3660).

This is part of testing the new `build-terraform-provider` CI step introduced in #3894. That step builds `terraform-provider-datadog` against the generated Go client to detect breaking changes early. When a breaking change is found, the `.github/terraform-provider-pr` file tells the CI to use the linked terraform provider PR branch (which contains the fix) instead of `master`.

In this case, the breaking change is `DashboardListDeleteItemsRequest` being renamed to `DashboardListRemoveItemsRequest` (from [datadog-api-spec#5370](https://github.com/DataDog/datadog-api-spec/pull/5370)), and the linked terraform PR contains the corresponding code update.

### Additional Notes

This is a test-only change to validate the end-to-end flow of the `build-terraform-provider` CI step. It will not be merged.

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [ ] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [x] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.