### PR TITLE
fix(generator): empty additionalProperties treated as falsy, breaking nullable map example generation (AAWF-1198)

### DIFF
--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -642,8 +642,8 @@ def format_data_with_schema_dict(
             )
             parameters += f"{camel_case(k)}: {value},\n"
 
-    additional = schema.get("additionalProperties")
-    if additional is not None and additional is not False:
+    additional = schema.get("additionalProperties", False)
+    if additional != False:
         saved_parameters = ""
         if schema.get("properties"):
             saved_parameters = parameters
@@ -677,7 +677,31 @@ def format_data_with_schema_dict(
                     **kwargs,
                 )
             else:
-                value = f'"{v}"'
+                # Infer schema from the Python value type so primitives are formatted
+                # correctly (e.g. strings with newlines use backtick literals, booleans
+                # emit "true"/"false"). bool must come before int because bool is a
+                # subclass of int in Python — format_interface would otherwise return
+                # "True"/"False" instead of valid Go literals.
+                # For complex types (dict, list) inferred stays {}: format_data_with_schema
+                # short-circuits on an empty schema and returns "", so the fallback
+                # f'"{v}"' emits a Python repr string. Not ideal but these values were
+                # previously silently dropped, so this is strictly an improvement.
+                if isinstance(v, bool):
+                    inferred = {"type": "boolean"}
+                elif isinstance(v, (int, float)):
+                    inferred = {"type": "number"}
+                elif isinstance(v, str):
+                    inferred = {"type": "string"}
+                else:
+                    inferred = {}
+                value = format_data_with_schema(
+                    v,
+                    inferred,
+                    name_prefix=name_prefix,
+                    replace_values=replace_values,
+                    required=True,
+                    **kwargs,
+                ) or f'"{v}"'
             parameters += f'"{k}": {value},\n'
 
             # IMPROVE: find a better way to get nested schema name

--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -642,33 +642,42 @@ def format_data_with_schema_dict(
             )
             parameters += f"{camel_case(k)}: {value},\n"
 
-    if schema.get("additionalProperties"):
+    additional = schema.get("additionalProperties")
+    if additional is not None and additional is not False:
         saved_parameters = ""
         if schema.get("properties"):
             saved_parameters = parameters
             parameters = ""
-        nested_schema = schema["additionalProperties"]
-        nested_schema_name = simple_type(nested_schema)
-        if not nested_schema_name:
-            nested_schema_name = schema_name(nested_schema)
-            if nested_schema_name:
-                nested_schema_name = name_prefix + nested_schema_name
-            elif nested_schema.get("type") is None:
-                nested_schema_name = "interface{}"
+        # Typed additionalProperties (non-empty dict): use it as the nested schema.
+        # Untyped (empty dict or True): any value is allowed, treat as interface{}.
+        nested_schema = additional if isinstance(additional, dict) and additional else None
+        if nested_schema:
+            nested_schema_name = simple_type(nested_schema)
+            if not nested_schema_name:
+                nested_schema_name = schema_name(nested_schema)
+                if nested_schema_name:
+                    nested_schema_name = name_prefix + nested_schema_name
+                elif nested_schema.get("type") is None:
+                    nested_schema_name = "interface{}"
+        else:
+            nested_schema_name = "interface{}"
 
         has_properties = schema.get("properties")
 
         for k, v in data.items():
             if has_properties and k in schema["properties"]:
                 continue
-            value = format_data_with_schema(
-                v,
-                schema["additionalProperties"],
-                name_prefix=name_prefix,
-                replace_values=replace_values,
-                required=True,
-                **kwargs,
-            )
+            if nested_schema:
+                value = format_data_with_schema(
+                    v,
+                    nested_schema,
+                    name_prefix=name_prefix,
+                    replace_values=replace_values,
+                    required=True,
+                    **kwargs,
+                )
+            else:
+                value = f'"{v}"'
             parameters += f'"{k}": {value},\n'
 
             # IMPROVE: find a better way to get nested schema name
@@ -687,14 +696,7 @@ def format_data_with_schema_dict(
         return _format_oneof(schema, data, name, name_prefix, replace_values, required, nullable, **kwargs)
 
     if schema.get("type") == "object" and "properties" not in schema:
-        if schema.get("additionalProperties") == {}:
-            name_prefix = ""
-            name = "map[string]interface{}"
-            reference = ""
-            for k, v in data.items():
-                parameters += f'"{k}": "{v}",\n'
-        else:
-            return "new(interface{})"
+        return "new(interface{})"
 
     if not name:
         raise ValueError(f"Unnamed schema {schema} for {data}")

--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -559,9 +559,18 @@ def format_data_with_schema_list(
             nested_schema_name = "interface{}"
     else:
         if nested_schema_name:
-            nested_schema_name = f"{name_prefix}{nested_schema_name}"
-        elif list_schema.get("type") == "object" and list_schema.get("additionalProperties") == {}:
-            nested_schema_name = "map[string]interface{}"
+            additional = list_schema.get("additionalProperties", False)
+            if additional != False and not list_schema.get("properties"):
+                # Named schema is a map type (no struct generated for it) — use the
+                # map type directly to avoid referencing a non-existent struct.
+                value_type = (simple_type(additional) if isinstance(additional, dict) and additional else None) or "interface{}"
+                nested_schema_name = f"map[string]{value_type}"
+            else:
+                nested_schema_name = f"{name_prefix}{nested_schema_name}"
+        elif list_schema.get("additionalProperties", False) != False:
+            additional = list_schema.get("additionalProperties")
+            value_type = (simple_type(additional) if isinstance(additional, dict) and additional else None) or "interface{}"
+            nested_schema_name = f"map[string]{value_type}"
         else:
             nested_schema_name = "interface{}"
 

--- a/.generator/tests/test_formatter.py
+++ b/.generator/tests/test_formatter.py
@@ -1,0 +1,53 @@
+# coding=utf-8
+"""Unit tests for the formatter module."""
+
+import pytest
+from generator.formatter import format_data_with_schema
+
+
+class SchemaWithRef(dict):
+    """A schema dict that carries a $ref, as the generator produces after resolving references."""
+
+    def __init__(self, *args, ref=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        if ref:
+            self.__reference__ = {"$ref": ref}
+
+
+class TestFormatDataWithSchemaAdditionalProperties:
+    """Tests for format_data_with_schema with additionalProperties schemas."""
+
+    def test_empty_additional_properties_with_nullable_generates_map_literal(self):
+        """additionalProperties: {} + nullable: true must not generate NewNullableXxx.
+
+        Before the fix, the Python truthiness of {} caused the additionalProperties
+        block to be skipped, falling through to the nullable path which generated
+        *NewNullableXxx(&Xxx{}) — a function that is never emitted by the model generator
+        for map schemas, causing a Go compile error.
+        """
+        schema = SchemaWithRef(
+            {"nullable": True, "additionalProperties": {}},
+            ref="#/components/schemas/CustomFields",
+        )
+        result = format_data_with_schema({"key": "value"}, schema)
+        assert result == 'map[string]interface{}{\n"key": "value",\n}'
+        assert "NewNullable" not in result
+
+    def test_empty_additional_properties_with_type_object_generates_map_literal(self):
+        """type: object + additionalProperties: {} + nullable: true must not generate NewNullableXxx."""
+        schema = SchemaWithRef(
+            {"type": "object", "nullable": True, "additionalProperties": {}},
+            ref="#/components/schemas/IncidentImpactFieldsObject",
+        )
+        result = format_data_with_schema({"field": "val"}, schema)
+        assert result == 'map[string]interface{}{\n"field": "val",\n}'
+        assert "NewNullable" not in result
+
+    def test_typed_additional_properties_generates_typed_map(self):
+        """additionalProperties: {type: string} must generate map[string]string{} as before."""
+        schema = SchemaWithRef(
+            {"type": "object", "nullable": True, "additionalProperties": {"type": "string"}},
+            ref="#/components/schemas/StringMap",
+        )
+        result = format_data_with_schema({"k": "v"}, schema)
+        assert result == 'map[string]string{\n"k": "v",\n}'

--- a/.generator/tests/test_formatter.py
+++ b/.generator/tests/test_formatter.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 """Unit tests for the formatter module."""
 
-import pytest
 from generator.formatter import format_data_with_schema
 
 

--- a/.generator/tests/test_formatter.py
+++ b/.generator/tests/test_formatter.py
@@ -50,3 +50,36 @@ class TestFormatDataWithSchemaAdditionalProperties:
         )
         result = format_data_with_schema({"k": "v"}, schema)
         assert result == 'map[string]string{\n"k": "v",\n}'
+
+
+class TestFormatDataWithSchemaArrayItems:
+    """Tests for format_data_with_schema with array items that are named map schemas."""
+
+    def test_named_empty_additional_properties_as_array_item_generates_map_slice(self):
+        """Array items that are named map schemas must generate []map[string]interface{}.
+
+        Before the fix, schema_name() returned "IDPConfigValueItem" for the item schema,
+        causing the formatter to emit []datadogV2.IDPConfigValueItem — a type that is never
+        generated for map schemas, causing a Go compile error.
+        """
+        item_schema = SchemaWithRef(
+            {"type": "object", "additionalProperties": {}},
+            ref="#/components/schemas/IDPConfigValueItem",
+        )
+        array_schema = {"type": "array", "items": item_schema}
+        result = format_data_with_schema(
+            [{"id": "dashboard-1", "displayName": "My Dashboard"}], array_schema
+        )
+        assert "IDPConfigValueItem" not in result
+        assert "map[string]interface{}" in result
+
+    def test_named_typed_additional_properties_as_array_item_generates_typed_map_slice(self):
+        """Array items that are named typed-map schemas must generate []map[string]string."""
+        item_schema = SchemaWithRef(
+            {"type": "object", "additionalProperties": {"type": "string"}},
+            ref="#/components/schemas/StringMapItem",
+        )
+        array_schema = {"type": "array", "items": item_schema}
+        result = format_data_with_schema([{"k": "v"}], array_schema)
+        assert "StringMapItem" not in result
+        assert "map[string]string" in result

--- a/examples/v2/actions-datastores/BulkWriteDatastoreItems.go
+++ b/examples/v2/actions-datastores/BulkWriteDatastoreItems.go
@@ -20,11 +20,11 @@ func main() {
 		Data: &datadogV2.BulkPutAppsDatastoreItemsRequestData{
 			Attributes: &datadogV2.BulkPutAppsDatastoreItemsRequestDataAttributes{
 				Values: []map[string]interface{}{
-					{
+					map[string]interface{}{
 						"id":   "cust_3141",
 						"name": "Johnathan",
 					},
-					{
+					map[string]interface{}{
 						"id":   "cust_3142",
 						"name": "Mary",
 					},

--- a/examples/v2/app-builder/CreateApp.go
+++ b/examples/v2/app-builder/CreateApp.go
@@ -2,197 +2,278 @@
 
 package main
 
+
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 
-	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+    "github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/google/uuid"
 )
 
 func main() {
 	body := datadogV2.CreateAppRequest{
-		Data: &datadogV2.CreateAppRequestData{
-			Type: datadogV2.APPDEFINITIONTYPE_APPDEFINITIONS,
-			Attributes: &datadogV2.CreateAppRequestDataAttributes{
-				RootInstanceName: datadog.PtrString("grid0"),
-				Components: []datadogV2.ComponentGrid{
-					{
-						Name: "grid0",
-						Type: datadogV2.COMPONENTGRIDTYPE_GRID,
-						Properties: datadogV2.ComponentGridProperties{
-							Children: []datadogV2.Component{
-								{
-									Type: datadogV2.COMPONENTTYPE_GRIDCELL,
-									Name: "gridCell0",
-									Properties: datadogV2.ComponentProperties{
-										Children: []datadogV2.Component{
-											{
-												Name: "text0",
-												Type: datadogV2.COMPONENTTYPE_TEXT,
-												Properties: datadogV2.ComponentProperties{
-													IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-														Bool: datadog.PtrBool(true)},
-												},
-												Events: []datadogV2.AppBuilderEvent{},
-											},
-										},
-										IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-											String: datadog.PtrString("true")},
-									},
-									Events: []datadogV2.AppBuilderEvent{},
-								},
-								{
-									Type: datadogV2.COMPONENTTYPE_GRIDCELL,
-									Name: "gridCell2",
-									Properties: datadogV2.ComponentProperties{
-										Children: []datadogV2.Component{
-											{
-												Name: "table0",
-												Type: datadogV2.COMPONENTTYPE_TABLE,
-												Properties: datadogV2.ComponentProperties{
-													IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-														Bool: datadog.PtrBool(true)},
-												},
-												Events: []datadogV2.AppBuilderEvent{},
-											},
-										},
-										IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-											String: datadog.PtrString("true")},
-									},
-									Events: []datadogV2.AppBuilderEvent{},
-								},
-								{
-									Type: datadogV2.COMPONENTTYPE_GRIDCELL,
-									Name: "gridCell1",
-									Properties: datadogV2.ComponentProperties{
-										Children: []datadogV2.Component{
-											{
-												Name: "text1",
-												Type: datadogV2.COMPONENTTYPE_TEXT,
-												Properties: datadogV2.ComponentProperties{
-													IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-														Bool: datadog.PtrBool(true)},
-												},
-												Events: []datadogV2.AppBuilderEvent{},
-											},
-										},
-										IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-											String: datadog.PtrString("true")},
-									},
-									Events: []datadogV2.AppBuilderEvent{},
-								},
-								{
-									Type: datadogV2.COMPONENTTYPE_GRIDCELL,
-									Name: "gridCell3",
-									Properties: datadogV2.ComponentProperties{
-										Children: []datadogV2.Component{
-											{
-												Name: "button0",
-												Type: datadogV2.COMPONENTTYPE_BUTTON,
-												Properties: datadogV2.ComponentProperties{
-													IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-														Bool: datadog.PtrBool(true)},
-												},
-												Events: []datadogV2.AppBuilderEvent{
-													{
-														Name: datadogV2.APPBUILDEREVENTNAME_CLICK.Ptr(),
-														Type: datadogV2.APPBUILDEREVENTTYPE_SETSTATEVARIABLEVALUE.Ptr(),
-													},
-												},
-											},
-										},
-										IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-											String: datadog.PtrString("true")},
-									},
-									Events: []datadogV2.AppBuilderEvent{},
-								},
-								{
-									Type: datadogV2.COMPONENTTYPE_GRIDCELL,
-									Name: "gridCell4",
-									Properties: datadogV2.ComponentProperties{
-										Children: []datadogV2.Component{
-											{
-												Name: "button1",
-												Type: datadogV2.COMPONENTTYPE_BUTTON,
-												Properties: datadogV2.ComponentProperties{
-													IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-														Bool: datadog.PtrBool(true)},
-												},
-												Events: []datadogV2.AppBuilderEvent{
-													{
-														Name: datadogV2.APPBUILDEREVENTNAME_CLICK.Ptr(),
-														Type: datadogV2.APPBUILDEREVENTTYPE_SETSTATEVARIABLEVALUE.Ptr(),
-													},
-												},
-											},
-										},
-										IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-											String: datadog.PtrString("true")},
-									},
-									Events: []datadogV2.AppBuilderEvent{},
-								},
-							},
-							BackgroundColor: datadog.PtrString("default"),
-						},
-						Events: []datadogV2.AppBuilderEvent{},
-					},
-				},
-				Queries: []datadogV2.Query{
-					datadogV2.Query{
-						ActionQuery: &datadogV2.ActionQuery{
-							Id:     uuid.MustParse("92ff0bb8-553b-4f31-87c7-ef5bd16d47d5"),
-							Type:   datadogV2.ACTIONQUERYTYPE_ACTION,
-							Name:   "fetchFacts",
-							Events: []datadogV2.AppBuilderEvent{},
-							Properties: datadogV2.ActionQueryProperties{
-								Spec: datadogV2.ActionQuerySpec{
-									ActionQuerySpecObject: &datadogV2.ActionQuerySpecObject{
-										Fqn:          "com.datadoghq.http.request",
-										ConnectionId: datadog.PtrString("5e63f4a8-4ce6-47de-ba11-f6617c1d54f3"),
-										Inputs: &datadogV2.ActionQuerySpecInputs{
-											ActionQuerySpecInput: map[string]interface{}{
-												"verb":      "GET",
-												"url":       "https://catfact.ninja/facts",
-												"urlParams": "[{'key': 'limit', 'value': '${pageSize.value.toString()}'}, {'key': 'page', 'value': '${(table0.pageIndex + 1).toString()}'}]",
-											}},
-									}},
-							},
-						}},
-					datadogV2.Query{
-						StateVariable: &datadogV2.StateVariable{
-							Type: datadogV2.STATEVARIABLETYPE_STATEVARIABLE,
-							Name: "pageSize",
-							Properties: datadogV2.StateVariableProperties{
-								DefaultValue: "${20}",
-							},
-							Id: uuid.MustParse("afd03c81-4075-4432-8618-ba09d52d2f2d"),
-						}},
-					datadogV2.Query{
-						DataTransform: &datadogV2.DataTransform{
-							Type: datadogV2.DATATRANSFORMTYPE_DATATRANSFORM,
-							Name: "randomFact",
-							Properties: datadogV2.DataTransformProperties{
-								Outputs: datadog.PtrString(`${(() => {const facts = fetchFacts.outputs.body.data
+Data: &datadogV2.CreateAppRequestData{
+Type: datadogV2.APPDEFINITIONTYPE_APPDEFINITIONS,
+Attributes: &datadogV2.CreateAppRequestDataAttributes{
+RootInstanceName: datadog.PtrString("grid0"),
+Components: []datadogV2.ComponentGrid{
+{
+Name: "grid0",
+Type: datadogV2.COMPONENTGRIDTYPE_GRID,
+Properties: datadogV2.ComponentGridProperties{
+Children: []datadogV2.Component{
+{
+Type: datadogV2.COMPONENTTYPE_GRIDCELL,
+Name: "gridCell0",
+Properties: datadogV2.ComponentProperties{
+Children: []datadogV2.Component{
+{
+Name: "text0",
+Type: datadogV2.COMPONENTTYPE_TEXT,
+Properties: datadogV2.ComponentProperties{
+IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+Bool: datadog.PtrBool(true)},
+AdditionalProperties: map[string]interface{}{
+"content": "# Cat Facts",
+"contentType": "markdown",
+"textAlign": "left",
+"verticalAlign": "top",
+},
+},
+Events: []datadogV2.AppBuilderEvent{
+},
+},
+},
+IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+String: datadog.PtrString("true")},
+AdditionalProperties: map[string]interface{}{
+"layout": "{'default': {'x': 0, 'y': 0, 'width': 4, 'height': 5}}",
+},
+},
+Events: []datadogV2.AppBuilderEvent{
+},
+},
+{
+Type: datadogV2.COMPONENTTYPE_GRIDCELL,
+Name: "gridCell2",
+Properties: datadogV2.ComponentProperties{
+Children: []datadogV2.Component{
+{
+Name: "table0",
+Type: datadogV2.COMPONENTTYPE_TABLE,
+Properties: datadogV2.ComponentProperties{
+IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+Bool: datadog.PtrBool(true)},
+AdditionalProperties: map[string]interface{}{
+"data": "${fetchFacts?.outputs?.body?.data}",
+"columns": "[{'dataPath': 'fact', 'header': 'fact', 'isHidden': False, 'id': '0ae2ae9e-0280-4389-83c6-1c5949f7e674'}, {'dataPath': 'length', 'header': 'length', 'isHidden': True, 'id': 'c9048611-0196-4a00-9366-1ef9e3ec0408'}, {'id': '8fa9284b-7a58-4f13-9959-57b7d8a7fe8f', 'dataPath': 'Due Date', 'header': 'Unused Old Column', 'disableSortBy': False, 'formatter': {'type': 'formatted_time', 'format': 'LARGE_WITHOUT_TIME'}, 'isDeleted': True}]",
+"summary": "True",
+"pageSize": "${pageSize?.value}",
+"paginationType": "server_side",
+"isLoading": "${fetchFacts?.isLoading}",
+"rowButtons": "[]",
+"isWrappable": "False",
+"isScrollable": "vertical",
+"isSubRowsEnabled": "False",
+"globalFilter": "False",
+"totalCount": "${fetchFacts?.outputs?.body?.total}",
+},
+},
+Events: []datadogV2.AppBuilderEvent{
+},
+},
+},
+IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+String: datadog.PtrString("true")},
+AdditionalProperties: map[string]interface{}{
+"layout": "{'default': {'x': 0, 'y': 5, 'width': 12, 'height': 96}}",
+},
+},
+Events: []datadogV2.AppBuilderEvent{
+},
+},
+{
+Type: datadogV2.COMPONENTTYPE_GRIDCELL,
+Name: "gridCell1",
+Properties: datadogV2.ComponentProperties{
+Children: []datadogV2.Component{
+{
+Name: "text1",
+Type: datadogV2.COMPONENTTYPE_TEXT,
+Properties: datadogV2.ComponentProperties{
+IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+Bool: datadog.PtrBool(true)},
+AdditionalProperties: map[string]interface{}{
+"content": "## Random Fact
+
+${randomFact?.outputs?.fact}",
+"contentType": "markdown",
+"textAlign": "left",
+"verticalAlign": "top",
+},
+},
+Events: []datadogV2.AppBuilderEvent{
+},
+},
+},
+IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+String: datadog.PtrString("true")},
+AdditionalProperties: map[string]interface{}{
+"layout": "{'default': {'x': 0, 'y': 101, 'width': 12, 'height': 16}}",
+},
+},
+Events: []datadogV2.AppBuilderEvent{
+},
+},
+{
+Type: datadogV2.COMPONENTTYPE_GRIDCELL,
+Name: "gridCell3",
+Properties: datadogV2.ComponentProperties{
+Children: []datadogV2.Component{
+{
+Name: "button0",
+Type: datadogV2.COMPONENTTYPE_BUTTON,
+Properties: datadogV2.ComponentProperties{
+IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+Bool: datadog.PtrBool(true)},
+AdditionalProperties: map[string]interface{}{
+"label": "Increase Page Size",
+"level": "default",
+"isPrimary": "True",
+"isBorderless": "False",
+"isLoading": "False",
+"isDisabled": "False",
+"iconLeft": "angleUp",
+"iconRight": "",
+},
+},
+Events: []datadogV2.AppBuilderEvent{
+{
+Name: datadogV2.APPBUILDEREVENTNAME_CLICK.Ptr(),
+Type: datadogV2.APPBUILDEREVENTTYPE_SETSTATEVARIABLEVALUE.Ptr(),
+AdditionalProperties: map[string]interface{}{
+"variableName": "pageSize",
+"value": "${pageSize?.value + 1}",
+},
+},
+},
+},
+},
+IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+String: datadog.PtrString("true")},
+AdditionalProperties: map[string]interface{}{
+"layout": "{'default': {'x': 10, 'y': 134, 'width': 2, 'height': 4}}",
+},
+},
+Events: []datadogV2.AppBuilderEvent{
+},
+},
+{
+Type: datadogV2.COMPONENTTYPE_GRIDCELL,
+Name: "gridCell4",
+Properties: datadogV2.ComponentProperties{
+Children: []datadogV2.Component{
+{
+Name: "button1",
+Type: datadogV2.COMPONENTTYPE_BUTTON,
+Properties: datadogV2.ComponentProperties{
+IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+Bool: datadog.PtrBool(true)},
+AdditionalProperties: map[string]interface{}{
+"label": "Decrease Page Size",
+"level": "default",
+"isPrimary": "True",
+"isBorderless": "False",
+"isLoading": "False",
+"isDisabled": "False",
+"iconLeft": "angleDown",
+"iconRight": "",
+},
+},
+Events: []datadogV2.AppBuilderEvent{
+{
+Name: datadogV2.APPBUILDEREVENTNAME_CLICK.Ptr(),
+Type: datadogV2.APPBUILDEREVENTTYPE_SETSTATEVARIABLEVALUE.Ptr(),
+AdditionalProperties: map[string]interface{}{
+"variableName": "pageSize",
+"value": "${pageSize?.value - 1}",
+},
+},
+},
+},
+},
+IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+String: datadog.PtrString("true")},
+AdditionalProperties: map[string]interface{}{
+"layout": "{'default': {'x': 10, 'y': 138, 'width': 2, 'height': 4}}",
+},
+},
+Events: []datadogV2.AppBuilderEvent{
+},
+},
+},
+BackgroundColor: datadog.PtrString("default"),
+},
+Events: []datadogV2.AppBuilderEvent{
+},
+},
+},
+Queries: []datadogV2.Query{
+datadogV2.Query{
+ActionQuery: &datadogV2.ActionQuery{
+Id: uuid.MustParse("92ff0bb8-553b-4f31-87c7-ef5bd16d47d5"),
+Type: datadogV2.ACTIONQUERYTYPE_ACTION,
+Name: "fetchFacts",
+Events: []datadogV2.AppBuilderEvent{
+},
+Properties: datadogV2.ActionQueryProperties{
+Spec: datadogV2.ActionQuerySpec{
+ActionQuerySpecObject: &datadogV2.ActionQuerySpecObject{
+Fqn: "com.datadoghq.http.request",
+ConnectionId: datadog.PtrString("5e63f4a8-4ce6-47de-ba11-f6617c1d54f3"),
+Inputs: &datadogV2.ActionQuerySpecInputs{
+ActionQuerySpecInput: map[string]interface{}{
+"verb": "GET",
+"url": "https://catfact.ninja/facts",
+"urlParams": "[{'key': 'limit', 'value': '${pageSize.value.toString()}'}, {'key': 'page', 'value': '${(table0.pageIndex + 1).toString()}'}]",
+}},
+}},
+},
+}},
+datadogV2.Query{
+StateVariable: &datadogV2.StateVariable{
+Type: datadogV2.STATEVARIABLETYPE_STATEVARIABLE,
+Name: "pageSize",
+Properties: datadogV2.StateVariableProperties{
+DefaultValue: "${20}",
+},
+Id: uuid.MustParse("afd03c81-4075-4432-8618-ba09d52d2f2d"),
+}},
+datadogV2.Query{
+DataTransform: &datadogV2.DataTransform{
+Type: datadogV2.DATATRANSFORMTYPE_DATATRANSFORM,
+Name: "randomFact",
+Properties: datadogV2.DataTransformProperties{
+Outputs: datadog.PtrString(`${(() => {const facts = fetchFacts.outputs.body.data
 return facts[Math.floor(Math.random()*facts.length)]
 })()}`),
-							},
-							Id: uuid.MustParse("0fb22859-47dc-4137-9e41-7b67d04c525c"),
-						}},
-				},
-				Name:        datadog.PtrString("Example Cat Facts Viewer"),
-				Description: datadog.PtrString("This is a slightly complicated example app that fetches and displays cat facts"),
-			},
-		},
-	}
+},
+Id: uuid.MustParse("0fb22859-47dc-4137-9e41-7b67d04c525c"),
+}},
+},
+Name: datadog.PtrString("Example Cat Facts Viewer"),
+Description: datadog.PtrString("This is a slightly complicated example app that fetches and displays cat facts"),
+},
+},
+}
 	ctx := datadog.NewDefaultContext(context.Background())
 	configuration := datadog.NewConfiguration()
 	apiClient := datadog.NewAPIClient(configuration)
 	api := datadogV2.NewAppBuilderApi(apiClient)
-	resp, r, err := api.CreateApp(ctx, body)
+	resp, r, err := api.CreateApp(ctx, body, )
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `AppBuilderApi.CreateApp`: %v\n", err)

--- a/examples/v2/app-builder/CreateApp.go
+++ b/examples/v2/app-builder/CreateApp.go
@@ -2,278 +2,268 @@
 
 package main
 
-
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
-    "github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/google/uuid"
 )
 
 func main() {
 	body := datadogV2.CreateAppRequest{
-Data: &datadogV2.CreateAppRequestData{
-Type: datadogV2.APPDEFINITIONTYPE_APPDEFINITIONS,
-Attributes: &datadogV2.CreateAppRequestDataAttributes{
-RootInstanceName: datadog.PtrString("grid0"),
-Components: []datadogV2.ComponentGrid{
-{
-Name: "grid0",
-Type: datadogV2.COMPONENTGRIDTYPE_GRID,
-Properties: datadogV2.ComponentGridProperties{
-Children: []datadogV2.Component{
-{
-Type: datadogV2.COMPONENTTYPE_GRIDCELL,
-Name: "gridCell0",
-Properties: datadogV2.ComponentProperties{
-Children: []datadogV2.Component{
-{
-Name: "text0",
-Type: datadogV2.COMPONENTTYPE_TEXT,
-Properties: datadogV2.ComponentProperties{
-IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-Bool: datadog.PtrBool(true)},
-AdditionalProperties: map[string]interface{}{
-"content": "# Cat Facts",
-"contentType": "markdown",
-"textAlign": "left",
-"verticalAlign": "top",
-},
-},
-Events: []datadogV2.AppBuilderEvent{
-},
-},
-},
-IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-String: datadog.PtrString("true")},
-AdditionalProperties: map[string]interface{}{
-"layout": "{'default': {'x': 0, 'y': 0, 'width': 4, 'height': 5}}",
-},
-},
-Events: []datadogV2.AppBuilderEvent{
-},
-},
-{
-Type: datadogV2.COMPONENTTYPE_GRIDCELL,
-Name: "gridCell2",
-Properties: datadogV2.ComponentProperties{
-Children: []datadogV2.Component{
-{
-Name: "table0",
-Type: datadogV2.COMPONENTTYPE_TABLE,
-Properties: datadogV2.ComponentProperties{
-IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-Bool: datadog.PtrBool(true)},
-AdditionalProperties: map[string]interface{}{
-"data": "${fetchFacts?.outputs?.body?.data}",
-"columns": "[{'dataPath': 'fact', 'header': 'fact', 'isHidden': False, 'id': '0ae2ae9e-0280-4389-83c6-1c5949f7e674'}, {'dataPath': 'length', 'header': 'length', 'isHidden': True, 'id': 'c9048611-0196-4a00-9366-1ef9e3ec0408'}, {'id': '8fa9284b-7a58-4f13-9959-57b7d8a7fe8f', 'dataPath': 'Due Date', 'header': 'Unused Old Column', 'disableSortBy': False, 'formatter': {'type': 'formatted_time', 'format': 'LARGE_WITHOUT_TIME'}, 'isDeleted': True}]",
-"summary": "True",
-"pageSize": "${pageSize?.value}",
-"paginationType": "server_side",
-"isLoading": "${fetchFacts?.isLoading}",
-"rowButtons": "[]",
-"isWrappable": "False",
-"isScrollable": "vertical",
-"isSubRowsEnabled": "False",
-"globalFilter": "False",
-"totalCount": "${fetchFacts?.outputs?.body?.total}",
-},
-},
-Events: []datadogV2.AppBuilderEvent{
-},
-},
-},
-IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-String: datadog.PtrString("true")},
-AdditionalProperties: map[string]interface{}{
-"layout": "{'default': {'x': 0, 'y': 5, 'width': 12, 'height': 96}}",
-},
-},
-Events: []datadogV2.AppBuilderEvent{
-},
-},
-{
-Type: datadogV2.COMPONENTTYPE_GRIDCELL,
-Name: "gridCell1",
-Properties: datadogV2.ComponentProperties{
-Children: []datadogV2.Component{
-{
-Name: "text1",
-Type: datadogV2.COMPONENTTYPE_TEXT,
-Properties: datadogV2.ComponentProperties{
-IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-Bool: datadog.PtrBool(true)},
-AdditionalProperties: map[string]interface{}{
-"content": "## Random Fact
+		Data: &datadogV2.CreateAppRequestData{
+			Type: datadogV2.APPDEFINITIONTYPE_APPDEFINITIONS,
+			Attributes: &datadogV2.CreateAppRequestDataAttributes{
+				RootInstanceName: datadog.PtrString("grid0"),
+				Components: []datadogV2.ComponentGrid{
+					{
+						Name: "grid0",
+						Type: datadogV2.COMPONENTGRIDTYPE_GRID,
+						Properties: datadogV2.ComponentGridProperties{
+							Children: []datadogV2.Component{
+								{
+									Type: datadogV2.COMPONENTTYPE_GRIDCELL,
+									Name: "gridCell0",
+									Properties: datadogV2.ComponentProperties{
+										Children: []datadogV2.Component{
+											{
+												Name: "text0",
+												Type: datadogV2.COMPONENTTYPE_TEXT,
+												Properties: datadogV2.ComponentProperties{
+													IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+														Bool: datadog.PtrBool(true)},
+													AdditionalProperties: map[string]interface{}{
+														"content":       "# Cat Facts",
+														"contentType":   "markdown",
+														"textAlign":     "left",
+														"verticalAlign": "top",
+													},
+												},
+												Events: []datadogV2.AppBuilderEvent{},
+											},
+										},
+										IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+											String: datadog.PtrString("true")},
+										AdditionalProperties: map[string]interface{}{
+											"layout": "{'default': {'x': 0, 'y': 0, 'width': 4, 'height': 5}}",
+										},
+									},
+									Events: []datadogV2.AppBuilderEvent{},
+								},
+								{
+									Type: datadogV2.COMPONENTTYPE_GRIDCELL,
+									Name: "gridCell2",
+									Properties: datadogV2.ComponentProperties{
+										Children: []datadogV2.Component{
+											{
+												Name: "table0",
+												Type: datadogV2.COMPONENTTYPE_TABLE,
+												Properties: datadogV2.ComponentProperties{
+													IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+														Bool: datadog.PtrBool(true)},
+													AdditionalProperties: map[string]interface{}{
+														"data":             "${fetchFacts?.outputs?.body?.data}",
+														"columns":          "[{'dataPath': 'fact', 'header': 'fact', 'isHidden': False, 'id': '0ae2ae9e-0280-4389-83c6-1c5949f7e674'}, {'dataPath': 'length', 'header': 'length', 'isHidden': True, 'id': 'c9048611-0196-4a00-9366-1ef9e3ec0408'}, {'id': '8fa9284b-7a58-4f13-9959-57b7d8a7fe8f', 'dataPath': 'Due Date', 'header': 'Unused Old Column', 'disableSortBy': False, 'formatter': {'type': 'formatted_time', 'format': 'LARGE_WITHOUT_TIME'}, 'isDeleted': True}]",
+														"summary":          true,
+														"pageSize":         "${pageSize?.value}",
+														"paginationType":   "server_side",
+														"isLoading":        "${fetchFacts?.isLoading}",
+														"rowButtons":       "[]",
+														"isWrappable":      false,
+														"isScrollable":     "vertical",
+														"isSubRowsEnabled": false,
+														"globalFilter":     false,
+														"totalCount":       "${fetchFacts?.outputs?.body?.total}",
+													},
+												},
+												Events: []datadogV2.AppBuilderEvent{},
+											},
+										},
+										IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+											String: datadog.PtrString("true")},
+										AdditionalProperties: map[string]interface{}{
+											"layout": "{'default': {'x': 0, 'y': 5, 'width': 12, 'height': 96}}",
+										},
+									},
+									Events: []datadogV2.AppBuilderEvent{},
+								},
+								{
+									Type: datadogV2.COMPONENTTYPE_GRIDCELL,
+									Name: "gridCell1",
+									Properties: datadogV2.ComponentProperties{
+										Children: []datadogV2.Component{
+											{
+												Name: "text1",
+												Type: datadogV2.COMPONENTTYPE_TEXT,
+												Properties: datadogV2.ComponentProperties{
+													IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+														Bool: datadog.PtrBool(true)},
+													AdditionalProperties: map[string]interface{}{
+														"content": `## Random Fact
 
-${randomFact?.outputs?.fact}",
-"contentType": "markdown",
-"textAlign": "left",
-"verticalAlign": "top",
-},
-},
-Events: []datadogV2.AppBuilderEvent{
-},
-},
-},
-IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-String: datadog.PtrString("true")},
-AdditionalProperties: map[string]interface{}{
-"layout": "{'default': {'x': 0, 'y': 101, 'width': 12, 'height': 16}}",
-},
-},
-Events: []datadogV2.AppBuilderEvent{
-},
-},
-{
-Type: datadogV2.COMPONENTTYPE_GRIDCELL,
-Name: "gridCell3",
-Properties: datadogV2.ComponentProperties{
-Children: []datadogV2.Component{
-{
-Name: "button0",
-Type: datadogV2.COMPONENTTYPE_BUTTON,
-Properties: datadogV2.ComponentProperties{
-IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-Bool: datadog.PtrBool(true)},
-AdditionalProperties: map[string]interface{}{
-"label": "Increase Page Size",
-"level": "default",
-"isPrimary": "True",
-"isBorderless": "False",
-"isLoading": "False",
-"isDisabled": "False",
-"iconLeft": "angleUp",
-"iconRight": "",
-},
-},
-Events: []datadogV2.AppBuilderEvent{
-{
-Name: datadogV2.APPBUILDEREVENTNAME_CLICK.Ptr(),
-Type: datadogV2.APPBUILDEREVENTTYPE_SETSTATEVARIABLEVALUE.Ptr(),
-AdditionalProperties: map[string]interface{}{
-"variableName": "pageSize",
-"value": "${pageSize?.value + 1}",
-},
-},
-},
-},
-},
-IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-String: datadog.PtrString("true")},
-AdditionalProperties: map[string]interface{}{
-"layout": "{'default': {'x': 10, 'y': 134, 'width': 2, 'height': 4}}",
-},
-},
-Events: []datadogV2.AppBuilderEvent{
-},
-},
-{
-Type: datadogV2.COMPONENTTYPE_GRIDCELL,
-Name: "gridCell4",
-Properties: datadogV2.ComponentProperties{
-Children: []datadogV2.Component{
-{
-Name: "button1",
-Type: datadogV2.COMPONENTTYPE_BUTTON,
-Properties: datadogV2.ComponentProperties{
-IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-Bool: datadog.PtrBool(true)},
-AdditionalProperties: map[string]interface{}{
-"label": "Decrease Page Size",
-"level": "default",
-"isPrimary": "True",
-"isBorderless": "False",
-"isLoading": "False",
-"isDisabled": "False",
-"iconLeft": "angleDown",
-"iconRight": "",
-},
-},
-Events: []datadogV2.AppBuilderEvent{
-{
-Name: datadogV2.APPBUILDEREVENTNAME_CLICK.Ptr(),
-Type: datadogV2.APPBUILDEREVENTTYPE_SETSTATEVARIABLEVALUE.Ptr(),
-AdditionalProperties: map[string]interface{}{
-"variableName": "pageSize",
-"value": "${pageSize?.value - 1}",
-},
-},
-},
-},
-},
-IsVisible: &datadogV2.ComponentPropertiesIsVisible{
-String: datadog.PtrString("true")},
-AdditionalProperties: map[string]interface{}{
-"layout": "{'default': {'x': 10, 'y': 138, 'width': 2, 'height': 4}}",
-},
-},
-Events: []datadogV2.AppBuilderEvent{
-},
-},
-},
-BackgroundColor: datadog.PtrString("default"),
-},
-Events: []datadogV2.AppBuilderEvent{
-},
-},
-},
-Queries: []datadogV2.Query{
-datadogV2.Query{
-ActionQuery: &datadogV2.ActionQuery{
-Id: uuid.MustParse("92ff0bb8-553b-4f31-87c7-ef5bd16d47d5"),
-Type: datadogV2.ACTIONQUERYTYPE_ACTION,
-Name: "fetchFacts",
-Events: []datadogV2.AppBuilderEvent{
-},
-Properties: datadogV2.ActionQueryProperties{
-Spec: datadogV2.ActionQuerySpec{
-ActionQuerySpecObject: &datadogV2.ActionQuerySpecObject{
-Fqn: "com.datadoghq.http.request",
-ConnectionId: datadog.PtrString("5e63f4a8-4ce6-47de-ba11-f6617c1d54f3"),
-Inputs: &datadogV2.ActionQuerySpecInputs{
-ActionQuerySpecInput: map[string]interface{}{
-"verb": "GET",
-"url": "https://catfact.ninja/facts",
-"urlParams": "[{'key': 'limit', 'value': '${pageSize.value.toString()}'}, {'key': 'page', 'value': '${(table0.pageIndex + 1).toString()}'}]",
-}},
-}},
-},
-}},
-datadogV2.Query{
-StateVariable: &datadogV2.StateVariable{
-Type: datadogV2.STATEVARIABLETYPE_STATEVARIABLE,
-Name: "pageSize",
-Properties: datadogV2.StateVariableProperties{
-DefaultValue: "${20}",
-},
-Id: uuid.MustParse("afd03c81-4075-4432-8618-ba09d52d2f2d"),
-}},
-datadogV2.Query{
-DataTransform: &datadogV2.DataTransform{
-Type: datadogV2.DATATRANSFORMTYPE_DATATRANSFORM,
-Name: "randomFact",
-Properties: datadogV2.DataTransformProperties{
-Outputs: datadog.PtrString(`${(() => {const facts = fetchFacts.outputs.body.data
+${randomFact?.outputs?.fact}`,
+														"contentType":   "markdown",
+														"textAlign":     "left",
+														"verticalAlign": "top",
+													},
+												},
+												Events: []datadogV2.AppBuilderEvent{},
+											},
+										},
+										IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+											String: datadog.PtrString("true")},
+										AdditionalProperties: map[string]interface{}{
+											"layout": "{'default': {'x': 0, 'y': 101, 'width': 12, 'height': 16}}",
+										},
+									},
+									Events: []datadogV2.AppBuilderEvent{},
+								},
+								{
+									Type: datadogV2.COMPONENTTYPE_GRIDCELL,
+									Name: "gridCell3",
+									Properties: datadogV2.ComponentProperties{
+										Children: []datadogV2.Component{
+											{
+												Name: "button0",
+												Type: datadogV2.COMPONENTTYPE_BUTTON,
+												Properties: datadogV2.ComponentProperties{
+													IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+														Bool: datadog.PtrBool(true)},
+													AdditionalProperties: map[string]interface{}{
+														"label":        "Increase Page Size",
+														"level":        "default",
+														"isPrimary":    true,
+														"isBorderless": false,
+														"isLoading":    false,
+														"isDisabled":   false,
+														"iconLeft":     "angleUp",
+														"iconRight":    "",
+													},
+												},
+												Events: []datadogV2.AppBuilderEvent{
+													{
+														Name: datadogV2.APPBUILDEREVENTNAME_CLICK.Ptr(),
+														Type: datadogV2.APPBUILDEREVENTTYPE_SETSTATEVARIABLEVALUE.Ptr(),
+														AdditionalProperties: map[string]interface{}{
+															"variableName": "pageSize",
+															"value":        "${pageSize?.value + 1}",
+														},
+													},
+												},
+											},
+										},
+										IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+											String: datadog.PtrString("true")},
+										AdditionalProperties: map[string]interface{}{
+											"layout": "{'default': {'x': 10, 'y': 134, 'width': 2, 'height': 4}}",
+										},
+									},
+									Events: []datadogV2.AppBuilderEvent{},
+								},
+								{
+									Type: datadogV2.COMPONENTTYPE_GRIDCELL,
+									Name: "gridCell4",
+									Properties: datadogV2.ComponentProperties{
+										Children: []datadogV2.Component{
+											{
+												Name: "button1",
+												Type: datadogV2.COMPONENTTYPE_BUTTON,
+												Properties: datadogV2.ComponentProperties{
+													IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+														Bool: datadog.PtrBool(true)},
+													AdditionalProperties: map[string]interface{}{
+														"label":        "Decrease Page Size",
+														"level":        "default",
+														"isPrimary":    true,
+														"isBorderless": false,
+														"isLoading":    false,
+														"isDisabled":   false,
+														"iconLeft":     "angleDown",
+														"iconRight":    "",
+													},
+												},
+												Events: []datadogV2.AppBuilderEvent{
+													{
+														Name: datadogV2.APPBUILDEREVENTNAME_CLICK.Ptr(),
+														Type: datadogV2.APPBUILDEREVENTTYPE_SETSTATEVARIABLEVALUE.Ptr(),
+														AdditionalProperties: map[string]interface{}{
+															"variableName": "pageSize",
+															"value":        "${pageSize?.value - 1}",
+														},
+													},
+												},
+											},
+										},
+										IsVisible: &datadogV2.ComponentPropertiesIsVisible{
+											String: datadog.PtrString("true")},
+										AdditionalProperties: map[string]interface{}{
+											"layout": "{'default': {'x': 10, 'y': 138, 'width': 2, 'height': 4}}",
+										},
+									},
+									Events: []datadogV2.AppBuilderEvent{},
+								},
+							},
+							BackgroundColor: datadog.PtrString("default"),
+						},
+						Events: []datadogV2.AppBuilderEvent{},
+					},
+				},
+				Queries: []datadogV2.Query{
+					datadogV2.Query{
+						ActionQuery: &datadogV2.ActionQuery{
+							Id:     uuid.MustParse("92ff0bb8-553b-4f31-87c7-ef5bd16d47d5"),
+							Type:   datadogV2.ACTIONQUERYTYPE_ACTION,
+							Name:   "fetchFacts",
+							Events: []datadogV2.AppBuilderEvent{},
+							Properties: datadogV2.ActionQueryProperties{
+								Spec: datadogV2.ActionQuerySpec{
+									ActionQuerySpecObject: &datadogV2.ActionQuerySpecObject{
+										Fqn:          "com.datadoghq.http.request",
+										ConnectionId: datadog.PtrString("5e63f4a8-4ce6-47de-ba11-f6617c1d54f3"),
+										Inputs: &datadogV2.ActionQuerySpecInputs{
+											ActionQuerySpecInput: map[string]interface{}{
+												"verb":      "GET",
+												"url":       "https://catfact.ninja/facts",
+												"urlParams": "[{'key': 'limit', 'value': '${pageSize.value.toString()}'}, {'key': 'page', 'value': '${(table0.pageIndex + 1).toString()}'}]",
+											}},
+									}},
+							},
+						}},
+					datadogV2.Query{
+						StateVariable: &datadogV2.StateVariable{
+							Type: datadogV2.STATEVARIABLETYPE_STATEVARIABLE,
+							Name: "pageSize",
+							Properties: datadogV2.StateVariableProperties{
+								DefaultValue: "${20}",
+							},
+							Id: uuid.MustParse("afd03c81-4075-4432-8618-ba09d52d2f2d"),
+						}},
+					datadogV2.Query{
+						DataTransform: &datadogV2.DataTransform{
+							Type: datadogV2.DATATRANSFORMTYPE_DATATRANSFORM,
+							Name: "randomFact",
+							Properties: datadogV2.DataTransformProperties{
+								Outputs: datadog.PtrString(`${(() => {const facts = fetchFacts.outputs.body.data
 return facts[Math.floor(Math.random()*facts.length)]
 })()}`),
-},
-Id: uuid.MustParse("0fb22859-47dc-4137-9e41-7b67d04c525c"),
-}},
-},
-Name: datadog.PtrString("Example Cat Facts Viewer"),
-Description: datadog.PtrString("This is a slightly complicated example app that fetches and displays cat facts"),
-},
-},
-}
+							},
+							Id: uuid.MustParse("0fb22859-47dc-4137-9e41-7b67d04c525c"),
+						}},
+				},
+				Name:        datadog.PtrString("Example Cat Facts Viewer"),
+				Description: datadog.PtrString("This is a slightly complicated example app that fetches and displays cat facts"),
+			},
+		},
+	}
 	ctx := datadog.NewDefaultContext(context.Background())
 	configuration := datadog.NewConfiguration()
 	apiClient := datadog.NewAPIClient(configuration)
 	api := datadogV2.NewAppBuilderApi(apiClient)
-	resp, r, err := api.CreateApp(ctx, body, )
+	resp, r, err := api.CreateApp(ctx, body)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `AppBuilderApi.CreateApp`: %v\n", err)

--- a/examples/v2/events/CreateEvent.go
+++ b/examples/v2/events/CreateEvent.go
@@ -38,12 +38,12 @@ func main() {
 							},
 						},
 						NewValue: map[string]interface{}{
-							"enabled":    "True",
+							"enabled":    true,
 							"percentage": "50%",
 							"rule":       "{'datacenter': 'devcycle.us1.prod'}",
 						},
 						PrevValue: map[string]interface{}{
-							"enabled":    "True",
+							"enabled":    true,
 							"percentage": "10%",
 							"rule":       "{'datacenter': 'devcycle.us1.prod'}",
 						},

--- a/examples/v2/fleet-automation/CreateFleetDeploymentConfigure.go
+++ b/examples/v2/fleet-automation/CreateFleetDeploymentConfigure.go
@@ -23,7 +23,7 @@ func main() {
 						Patch: map[string]interface{}{
 							"apm_config":   "{'enabled': True}",
 							"log_level":    "debug",
-							"logs_enabled": "True",
+							"logs_enabled": true,
 						},
 					},
 				},

--- a/examples/v2/security-monitoring/TestSecurityMonitoringRule.go
+++ b/examples/v2/security-monitoring/TestSecurityMonitoringRule.go
@@ -62,6 +62,9 @@ func main() {
 					Hostname: datadog.PtrString("i-012345678"),
 					Message:  datadog.PtrString("2019-11-19T14:37:58,995 INFO [process.name][20081] Hello World"),
 					Service:  datadog.PtrString("payment"),
+					AdditionalProperties: map[string]interface{}{
+						"userIdentity": "{'assumed_role': 'fake assumed_role'}",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Context

While working on a validation rule for openapi-transformer related to a failing run, I traced the root cause to the generator itself.

Two related bugs in the example formatter caused Go compile errors for schemas with `additionalProperties: {}`:

**Bug 1 — Nullable map schemas:** the original ticket suspected the issue was about `required` + `nullable`, but `required` is irrelevant. The real problem: the Go generator skips creating a named type for map schemas (`additionalProperties`, no fixed `properties`). When such a schema also has `nullable: true`, the example generator still writes a `NewNullable<SchemaName>()` call referencing a type that was never created, causing a compile error.

Schemas with typed `additionalProperties` (e.g. `{type: string}`) are safe — the generator returns a `map[string]string{}` literal early and never reaches the nullable path. The crash only happens with empty/untyped `additionalProperties: {}`.

The root cause: `additionalProperties: {}` is an empty dict, which is falsy in Python. This caused the `additionalProperties` handling block to be silently skipped, falling through to the nullable path and emitting `*NewNullableXxx(&Xxx{})` — a constructor that is never generated for map schemas.

**Bug 2 — Named map schemas as array items:** for a schema with `additionalProperties: {}` used as a `$ref` in array items, `schema_name()` returned the ref name (e.g. `IDPConfigValueItem`) which was used directly as the array element type `[]datadogV2.IDPConfigValueItem`. But no struct is generated for map schemas — the model generator skips them — so the reference was undefined. An `elif` at line 563 was meant to handle this case but only fired for anonymous schemas; named map schemas fell into the `if nested_schema_name:` branch, bypassing the map type fallback.

Both bugs stem from the same pattern: the formatter used `schema_name()` directly without checking whether the referenced schema actually produces a generated struct.

## Summary

**Bug 1 fix:**
- Fix the condition from `if schema.get("additionalProperties"):` to `if additional != False:` (consistent with the same check in `openapi.py`), so that `additionalProperties: {}` correctly enters the map handling block
- When `additionalProperties` is an empty dict or boolean true, treat `interface{}` as the nested value type
- For values in untyped maps, infer schema from the Python value type so string escaping, bool/number formatting are handled correctly — this also surfaces a pre-existing silent bug where extra fields in mixed schemas (both `properties` and `additionalProperties: {}`, e.g. `ComponentProperties`) were being silently dropped from generated examples
- Remove the now-unreachable dead-code branch that previously attempted to handle `type: object + additionalProperties: {}` after the nullable check

**Bug 2 fix:**
- When a named schema has `additionalProperties` set and no `properties`, resolve it to `map[string]T` instead of using the struct name — consistent with how `type_to_go()` handles the same case

## Test plan

- [ ] New unit tests in `tests/test_formatter.py` covering: empty `additionalProperties` (no type), empty `additionalProperties` (with `type: object`), typed `additionalProperties`, named map schema as array item (untyped), named map schema as array item (typed)
- [ ] Full generator test suite passes (`poetry run pytest` — 3250 tests)
- [ ] Verified against the exact schema from the nullable failing run: `JiraIssueCustomFields` (`nullable: true`, `additionalProperties: {}`) now generates `map[string]interface{}{}` instead of `*NewNullableJiraIssueCustomFields()`
- [ ] Verified against the exact schema from the array items failing run: `IDPConfigValueItem` (`type: object`, `additionalProperties: {}`) used as array items now generates `[]map[string]interface{}` instead of `[]datadogV2.IDPConfigValueItem`
