### PR TITLE
[security_monitoring] Expand ForgetAfter and LearningDuration enum validation to accept 1-30

### DIFF
--- a/api/datadogV2/model_security_monitoring_rule_new_value_options_forget_after.go
+++ b/api/datadogV2/model_security_monitoring_rule_new_value_options_forget_after.go
@@ -23,18 +23,13 @@ const (
 	SECURITYMONITORINGRULENEWVALUEOPTIONSFORGETAFTER_FOUR_WEEKS  SecurityMonitoringRuleNewValueOptionsForgetAfter = 28
 )
 
-var allowedSecurityMonitoringRuleNewValueOptionsForgetAfterEnumValues = []SecurityMonitoringRuleNewValueOptionsForgetAfter{
-	SECURITYMONITORINGRULENEWVALUEOPTIONSFORGETAFTER_ONE_DAY,
-	SECURITYMONITORINGRULENEWVALUEOPTIONSFORGETAFTER_TWO_DAYS,
-	SECURITYMONITORINGRULENEWVALUEOPTIONSFORGETAFTER_ONE_WEEK,
-	SECURITYMONITORINGRULENEWVALUEOPTIONSFORGETAFTER_TWO_WEEKS,
-	SECURITYMONITORINGRULENEWVALUEOPTIONSFORGETAFTER_THREE_WEEKS,
-	SECURITYMONITORINGRULENEWVALUEOPTIONSFORGETAFTER_FOUR_WEEKS,
-}
-
-// GetAllowedValues reeturns the list of possible values.
+// GetAllowedValues returns the list of possible values (1 through 30).
 func (v *SecurityMonitoringRuleNewValueOptionsForgetAfter) GetAllowedValues() []SecurityMonitoringRuleNewValueOptionsForgetAfter {
-	return allowedSecurityMonitoringRuleNewValueOptionsForgetAfterEnumValues
+	values := make([]SecurityMonitoringRuleNewValueOptionsForgetAfter, 30)
+	for i := range values {
+		values[i] = SecurityMonitoringRuleNewValueOptionsForgetAfter(i + 1)
+	}
+	return values
 }
 
 // UnmarshalJSON deserializes the given payload.
@@ -55,17 +50,12 @@ func NewSecurityMonitoringRuleNewValueOptionsForgetAfterFromValue(v int32) (*Sec
 	if ev.IsValid() {
 		return &ev, nil
 	}
-	return nil, fmt.Errorf("invalid value '%v' for SecurityMonitoringRuleNewValueOptionsForgetAfter: valid values are %v", v, allowedSecurityMonitoringRuleNewValueOptionsForgetAfterEnumValues)
+	return nil, fmt.Errorf("invalid value '%v' for SecurityMonitoringRuleNewValueOptionsForgetAfter: valid values are 1 through 30", v)
 }
 
 // IsValid return true if the value is valid for the enum, false otherwise.
 func (v SecurityMonitoringRuleNewValueOptionsForgetAfter) IsValid() bool {
-	for _, existing := range allowedSecurityMonitoringRuleNewValueOptionsForgetAfterEnumValues {
-		if existing == v {
-			return true
-		}
-	}
-	return false
+	return v >= 1 && v <= 30
 }
 
 // Ptr returns reference to SecurityMonitoringRuleNewValueOptionsForgetAfter value.

--- a/api/datadogV2/model_security_monitoring_rule_new_value_options_learning_duration.go
+++ b/api/datadogV2/model_security_monitoring_rule_new_value_options_learning_duration.go
@@ -21,15 +21,13 @@ const (
 	SECURITYMONITORINGRULENEWVALUEOPTIONSLEARNINGDURATION_SEVEN_DAYS SecurityMonitoringRuleNewValueOptionsLearningDuration = 7
 )
 
-var allowedSecurityMonitoringRuleNewValueOptionsLearningDurationEnumValues = []SecurityMonitoringRuleNewValueOptionsLearningDuration{
-	SECURITYMONITORINGRULENEWVALUEOPTIONSLEARNINGDURATION_ZERO_DAYS,
-	SECURITYMONITORINGRULENEWVALUEOPTIONSLEARNINGDURATION_ONE_DAY,
-	SECURITYMONITORINGRULENEWVALUEOPTIONSLEARNINGDURATION_SEVEN_DAYS,
-}
-
-// GetAllowedValues reeturns the list of possible values.
+// GetAllowedValues returns the list of possible values (0 through 30).
 func (v *SecurityMonitoringRuleNewValueOptionsLearningDuration) GetAllowedValues() []SecurityMonitoringRuleNewValueOptionsLearningDuration {
-	return allowedSecurityMonitoringRuleNewValueOptionsLearningDurationEnumValues
+	values := make([]SecurityMonitoringRuleNewValueOptionsLearningDuration, 31)
+	for i := range values {
+		values[i] = SecurityMonitoringRuleNewValueOptionsLearningDuration(i)
+	}
+	return values
 }
 
 // UnmarshalJSON deserializes the given payload.
@@ -50,17 +48,12 @@ func NewSecurityMonitoringRuleNewValueOptionsLearningDurationFromValue(v int32) 
 	if ev.IsValid() {
 		return &ev, nil
 	}
-	return nil, fmt.Errorf("invalid value '%v' for SecurityMonitoringRuleNewValueOptionsLearningDuration: valid values are %v", v, allowedSecurityMonitoringRuleNewValueOptionsLearningDurationEnumValues)
+	return nil, fmt.Errorf("invalid value '%v' for SecurityMonitoringRuleNewValueOptionsLearningDuration: valid values are 0 through 30", v)
 }
 
 // IsValid return true if the value is valid for the enum, false otherwise.
 func (v SecurityMonitoringRuleNewValueOptionsLearningDuration) IsValid() bool {
-	for _, existing := range allowedSecurityMonitoringRuleNewValueOptionsLearningDurationEnumValues {
-		if existing == v {
-			return true
-		}
-	}
-	return false
+	return v >= 0 && v <= 30
 }
 
 // Ptr returns reference to SecurityMonitoringRuleNewValueOptionsLearningDuration value.


### PR DESCRIPTION
## Problem

`SecurityMonitoringRuleNewValueOptionsForgetAfter.IsValid()` only accepts {1, 2, 7, 14, 21, 28} and `SecurityMonitoringRuleNewValueOptionsLearningDuration.IsValid()` only accepts {0, 1, 7}. The Datadog API accepts and returns any value between 1-30 for `forgetAfter` and 0-30 for `learningDuration`.

When `UnmarshalJSON` on `SecurityMonitoringRuleNewValueOptions` encounters `forgetAfter: 30` from the API, `IsValid()` returns false, `hasInvalidField` is set to true, and the entire object is stored in `UnparsedObject`. This causes downstream consumers (including the Terraform provider) to fail with "object contains unparsed element."

## Fix

Replace the loop-based `IsValid()` with a range check:
- `ForgetAfter`: `v >= 1 && v <= 30`
- `LearningDuration`: `v >= 0 && v <= 30`

The named constants and `allowedValues` slice are preserved for backward compatibility.

## Evidence

Several of our custom rules return `forgetAfter=30` and `learningDuration=30` from the API. The existing test cassette (`TestAccDatadogSecurityMonitoringRule_NewValueRule`) only covers `forgetAfter=7` and `learningDuration=1`, so the gap was never caught.

## Related

- terraform-provider-datadog#3699