### PR TITLE
fix(generator): nullable inline object schema crashes on nil value

### DIFF
--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -268,6 +268,8 @@ def reference_to_value(schema, value, print_nullable=True, **kwargs):
     if nullable:
         function_name = schema_name(schema)
         if function_name is None:
+            if value == "nil":
+                return "nil"
             raise NotImplementedError(f"nullable {schema} is not supported")
         return formatter.format(prefix=prefix, function_name=function_name, value=value)
     return f"&{value}"

--- a/.generator/tests/test_formatter.py
+++ b/.generator/tests/test_formatter.py
@@ -83,3 +83,15 @@ class TestFormatDataWithSchemaArrayItems:
         result = format_data_with_schema([{"k": "v"}], array_schema)
         assert "StringMapItem" not in result
         assert "map[string]string" in result
+
+
+class TestNullableInlineObjectWithNullValue:
+    """Nullable inline (anonymous) object schemas must return 'nil' when data is None."""
+
+    def test_nullable_inline_object_returns_nil(self):
+        schema = {"type": "object", "nullable": True}
+        assert format_data_with_schema(None, schema) == "nil"
+
+    def test_nullable_inline_object_with_additional_properties_returns_nil(self):
+        schema = {"type": "object", "nullable": True, "additionalProperties": {}}
+        assert format_data_with_schema(None, schema) == "nil"


### PR DESCRIPTION
## Summary

- `reference_to_value` raised `NotImplementedError` when a BDD scenario sent `null` for a nullable field whose schema is an inline object (no `$ref`)
- The guard was a placeholder from the initial implementation (April 2022, commit `5172f6dc6`) — it was never deliberately designed, just never hit until now
- Fix: when `value == "nil"` and no named type is available, return `"nil"` directly — there is nothing to wrap
- The `NotImplementedError` for the non-nil anonymous case is preserved (genuinely unsupported, and unreachable for `type: object` in practice)

## Test plan

- [ ] `poetry run pytest tests/test_formatter.py -v` — 7 tests pass (5 existing + 2 new)
- [ ] Two new tests cover `data=None` with `{type: object, nullable: true}` and with `additionalProperties: {}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Run the generator with those changes and I confirmed there were no changes