### PR TITLE
ci: temporarily disable build-terraform-provider job

### DIFF
--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -77,6 +77,7 @@ jobs:
           TESTARGS: ${{ matrix.go-build-tags }}
 
   build-terraform-provider:
+    if: false # temporarily disabled
     runs-on: ubuntu-latest
     steps:
       - name: Get GitHub App token


### PR DESCRIPTION
### What does this PR do?

Temporarily disables the `build-terraform-provider` job in `.github/workflows/reusable-go-test.yml` by adding `if: false` to the job. The job is skipped in every context that calls `reusable-go-test.yml` (this repo's `test.yml` and the externally-called `reusable-ci.yml`) until the condition is removed.

### Additional Notes

Intended as a short-term workaround; revert the `if: false` line to re-enable the check.

### Review checklist

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.
- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.