### PR TITLE
Speed up staticcheck times

### DIFF
--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -39,18 +39,20 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
-          cache-dependency-path: tests/go.sum
+          cache-dependency-path: |
+            go.sum
+            tests/go.sum
       - name: Staticcheck (api module)
         uses: dominikh/staticcheck-action@v1
         with:
           checks: "-SA1009"
           working-directory: api
-          cache-key: ${{ matrix.go }}
+          cache-key: ${{ matrix.go-version }}
       - name: Staticcheck (tests module)
         uses: dominikh/staticcheck-action@v1
         with:
           checks: "inherit,-SA1019"
-          cache-key: ${{ matrix.go }}
+          cache-key: ${{ matrix.go-version }}
           working-directory: tests
   test:
     strategy:


### PR DESCRIPTION
<!--
** Requirements for Contributing to this repository **

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?
staticcheck runtime from 10-12 minutes (https://github.com/DataDog/datadog-api-client-go/actions/runs/25687009220/job/75413297594) to <1 minute (https://github.com/DataDog/datadog-api-client-go/actions/runs/25687629735/job/75415394123)
<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature."
If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [ ] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
