### PR TITLE
ci: remove single-value platform matrix dimension

### DIFF
--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -26,8 +26,7 @@ jobs:
       matrix:
         go-version: ["1.22.x", "1.23.x"]
         go-build-tags: ["--tags=goccy_gojson", ""]
-        platform: ["ubuntu-latest"]
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -59,8 +58,7 @@ jobs:
       matrix:
         go-version: ["1.22.x", "1.23.x"]
         go-build-tags: ["--tags=goccy_gojson", ""]
-        platform: ["ubuntu-latest"]
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- The `platform` matrix only contained `["ubuntu-latest"]` — a matrix with one value that adds noise to the config and GitHub Actions UI without testing anything
- Hardcode `runs-on: ubuntu-latest` directly on both `staticcheck` and `test` jobs

## Stack
1/6 — **this PR**
2/6 — ci: upgrade action versions
3/6 — ci: reduce staticcheck matrix
4/6 — ci: extract license check
5/6 — ci: cache Go build cache
6/6 — ci: optimize gotestsum install

## Test plan
- [ ] Verify CI jobs still run correctly on `ubuntu-latest`
- [ ] Confirm job names in Actions UI no longer include redundant platform suffix


🤖 Generated with [Claude Code](https://claude.com/claude-code)