### PR TITLE
ci: upgrade checkout to v4 and setup-go to v5

### DIFF
--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -29,15 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: DataDog/datadog-api-client-go
           ref: ${{ inputs.target-branch || github.ref }}
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-          cache: true
           cache-dependency-path: |
             go.sum
             tests/go.sum
@@ -61,16 +60,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: DataDog/datadog-api-client-go
           ref: ${{ inputs.target-branch || github.ref }}
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-          cache: true
-          cache-dependency-path: tests/go.sum
+          cache-dependency-path: |
+            go.sum
+            tests/go.sum
       - name: Test
         run: ./scripts/run-tests.sh
         env:


### PR DESCRIPTION
## Summary
- `actions/checkout` v3 -> v4: faster sparse checkout, Node 20 runtime
- `actions/setup-go` v4 -> v5: cache enabled by default (removed explicit `cache: true`), improved cache key generation
- Aligned test job `cache-dependency-path` to include both `go.sum` and `tests/go.sum`

## Stack
1/6 — ci: remove platform matrix (#4083)
2/6 — **this PR**
3/6 — ci: reduce staticcheck matrix
4/6 — ci: extract license check
5/6 — ci: cache Go build cache
6/6 — ci: optimize gotestsum install

## Test plan
- [ ] Verify Go module caching works correctly with setup-go v5
- [ ] Confirm checkout v4 works with the `repository` + `ref` inputs


🤖 Generated with [Claude Code](https://claude.com/claude-code)