### PR TITLE
ci: run staticcheck once instead of 4x matrix

### DIFF
--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -22,10 +22,6 @@ on:
 
 jobs:
   staticcheck:
-    strategy:
-      matrix:
-        go-version: ["1.22.x", "1.23.x"]
-        go-build-tags: ["--tags=goccy_gojson", ""]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -36,7 +32,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: "1.23.x"
           cache-dependency-path: |
             go.sum
             tests/go.sum
@@ -45,12 +41,10 @@ jobs:
         with:
           checks: "-SA1009"
           working-directory: api
-          cache-key: ${{ matrix.go-version }}
       - name: Staticcheck (tests module)
         uses: dominikh/staticcheck-action@v1
         with:
           checks: "inherit,-SA1019"
-          cache-key: ${{ matrix.go-version }}
           working-directory: tests
   test:
     strategy:


### PR DESCRIPTION
## Summary
- Static analysis results don't vary across Go minor versions (1.22 vs 1.23) or build tags (`--tags=goccy_gojson` vs default)
- Remove the matrix and run staticcheck once with Go 1.23.x, reducing from 4 jobs to 1

## Stack
1/6 — ci: remove platform matrix (#4083)
2/6 — ci: upgrade action versions (#4084)
3/6 — **this PR**
4/6 — ci: extract license check
5/6 — ci: cache Go build cache
6/6 — ci: optimize gotestsum install

## Test plan
- [ ] Verify staticcheck still runs and catches issues on the single Go version
- [ ] Confirm no regressions in static analysis coverage


🤖 Generated with [Claude Code](https://claude.com/claude-code)