### PR TITLE
ci: extract license check into its own job

### DIFF
--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -21,6 +21,24 @@ on:
         required: false
 
 jobs:
+  license-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          repository: DataDog/datadog-api-client-go
+          ref: ${{ inputs.target-branch || github.ref }}
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.x"
+          cache-dependency-path: |
+            go.sum
+            tests/go.sum
+      - name: Check LICENSE-3rdparty.csv
+        run: ./scripts/check-licenses.sh
+
   staticcheck:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check-licenses.sh
+++ b/scripts/check-licenses.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Ensuring all dependencies are present in LICENSE-3rdparty.csv ..."
+go mod tidy
+ALL_DEPS=$(cat go.sum tests/go.sum | awk '{print $1}' | uniq | sort | sed "s|^\(.*\)|go.sum,\1,|")
+DEPS_NOT_FOUND=""
+set +e
+for one_dep in $ALL_DEPS; do
+    cat LICENSE-3rdparty.csv | grep "$one_dep" > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        DEPS_NOT_FOUND="${DEPS_NOT_FOUND}\n${one_dep}<LICENSE>,<COPYRIGHT>"
+    fi
+done
+set -e
+if [ -n "$DEPS_NOT_FOUND" ]; then
+    echo "Some dependencies were not found in LICENSE-3rdparty.csv, please add: $DEPS_NOT_FOUND"
+    exit 1
+else
+    echo "LICENSE-3rdparty.csv is up to date"
+fi

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,25 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-echo "Ensuring all dependencies are present in LICENSE-3rdparty.csv ..."
-go mod tidy
-ALL_DEPS=$(cat go.sum tests/go.sum | awk '{print $1}' | uniq | sort | sed "s|^\(.*\)|go.sum,\1,|")
-DEPS_NOT_FOUND=""
-set +e
-for one_dep in $ALL_DEPS; do
-    cat LICENSE-3rdparty.csv | grep "$one_dep" > /dev/null 2>&1
-    if [ $? -ne 0 ]; then
-        DEPS_NOT_FOUND="${DEPS_NOT_FOUND}\n${one_dep}<LICENSE>,<COPYRIGHT>"
-    fi
-done
-set -e
-if [ -n "$DEPS_NOT_FOUND" ]; then
-    echo "Some dependencies were not found in LICENSE-3rdparty.csv, please add: $DEPS_NOT_FOUND"
-    exit 1
-else
-    echo "LICENSE-3rdparty.csv is up to date"
-fi
-
 # make sure the below installed dependencies don't get added to go.mod/go.sum
 # unfortunately there's no better way to fix this than change directory
 # this might get solved in Go 1.14: https://github.com/golang/go/issues/30515


### PR DESCRIPTION
## Summary
- The LICENSE-3rdparty.csv check ran once per test matrix combination (4 times) despite being identical across Go versions and build tags
- Moved it into a dedicated `license-check` job that runs once
- Split the check into a new `scripts/check-licenses.sh` for clarity, keeping `scripts/run-tests.sh` focused on tests

## Stack
1/6 — ci: remove platform matrix (#4083)
2/6 — ci: upgrade action versions (#4084)
3/6 — ci: reduce staticcheck matrix (#4085)
4/6 — **this PR**
5/6 — ci: cache Go build cache
6/6 — ci: optimize gotestsum install

## Test plan
- [ ] Verify the new `license-check` job runs and catches missing licenses
- [ ] Verify `run-tests.sh` still works correctly without the license check
- [ ] Confirm `check-licenses.sh` is executable


🤖 Generated with [Claude Code](https://claude.com/claude-code)