### PR TITLE
ci: cache Go build cache (GOCACHE) for test jobs

### DIFF
--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -83,6 +83,14 @@ jobs:
           cache-dependency-path: |
             go.sum
             tests/go.sum
+      - name: Cache Go build cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-build-${{ matrix.go-version }}-${{ matrix.go-build-tags }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-build-${{ matrix.go-version }}-${{ matrix.go-build-tags }}-
+            go-build-${{ matrix.go-version }}-
       - name: Test
         run: ./scripts/run-tests.sh
         env:


### PR DESCRIPTION
## Summary
- `setup-go` only caches downloaded modules (GOMODCACHE), not compiled object files (GOCACHE at `~/.cache/go-build`)
- Added an explicit `actions/cache@v4` step for the Go build cache, keyed on Go version, build tags, and `go.sum` hash
- The test script's `go clean -testcache` only clears test *results*, not compiled packages, so this cache remains effective for speeding up compilation

## Stack
1/6 — ci: remove platform matrix (#4083)
2/6 — ci: upgrade action versions (#4084)
3/6 — ci: reduce staticcheck matrix (#4085)
4/6 — ci: extract license check (#4086)
5/6 — **this PR**
6/6 — ci: optimize gotestsum install

## Test plan
- [ ] First run populates the cache (cache miss)
- [ ] Subsequent runs hit the cache and compile faster
- [ ] Verify different matrix combos get separate cache entries


🤖 Generated with [Claude Code](https://claude.com/claude-code)