### PR TITLE
ci: install gotestsum from pre-built binary

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
-# make sure the below installed dependencies don't get added to go.mod/go.sum
-# unfortunately there's no better way to fix this than change directory
-# this might get solved in Go 1.14: https://github.com/golang/go/issues/30515
-echo "Installing gotestsum"
-cd "$(mktemp -d)"
-GO111MODULE=on go install gotest.tools/gotestsum@latest
-cd -
+GOTESTSUM_VERSION="1.13.0"
+
+if ! command -v gotestsum &> /dev/null; then
+    echo "Installing gotestsum v${GOTESTSUM_VERSION} (pre-built binary)"
+    curl -sSfL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz" \
+        | tar -xz -C "$(go env GOPATH)/bin" gotestsum
+else
+    echo "gotestsum already installed"
+fi
 
 echo "Running mod tidy and cleanup test cache"
 go mod tidy


### PR DESCRIPTION
## Summary
- Previously every CI run compiled gotestsum from source via `go install gotest.tools/gotestsum@latest` (~30s+ including download and compile)
- Now downloads the pre-built binary from GitHub releases (~2s)
- Pins version to v1.13.0 for reproducibility (was using unpinned `@latest`)
- Skips download if `gotestsum` is already available (supports potential future caching)

## Stack
1/6 — ci: remove platform matrix (#4083)
2/6 — ci: upgrade action versions (#4084)
3/6 — ci: reduce staticcheck matrix (#4085)
4/6 — ci: extract license check (#4086)
5/6 — ci: cache Go build cache (#4087)
6/6 — **this PR**

## Test plan
- [ ] Verify gotestsum binary downloads and runs correctly on ubuntu-latest
- [ ] Verify test output format is unchanged
- [ ] Confirm the `command -v` check works (skips download when already present)


🤖 Generated with [Claude Code](https://claude.com/claude-code)