### PR TITLE
Pin goimports in pre-commit to v0.30.0 for Go 1.22 compat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     # types: ["file", "go"]
     pass_filenames: false
     additional_dependencies:
-      - golang.org/x/tools/cmd/goimports@latest
+      - golang.org/x/tools/cmd/goimports@v0.30.0
   - id: generate-doc
     name: Doc generation
     stages: [manual]


### PR DESCRIPTION
## Summary
- After pinning `actions/setup-go` to v6.4.0 in #4155, the `reusable-pre-commit` job runs with `GOTOOLCHAIN=local` (the v6 default)
- pre-commit's Lint hook installs `goimports@latest`, which now resolves to `golang.org/x/tools@v0.45.0` and requires Go ≥ 1.25 — install fails under Go 1.22.12 with `GOTOOLCHAIN=local`, leaving generated files un-formatted and breaking the `Generate` hook in downstream `datadog-api-spec` PRs (see [run](https://github.com/DataDog/datadog-api-spec/actions/runs/26527875504/job/78140401441?pr=5809))
- `v0.30.0` is the last `golang.org/x/tools` release whose `go.mod` still declares `go 1.22.0`; `v0.31.0+` require Go 1.23+
- Pinning keeps the pre-commit job honest on the declared 1.22.x toolchain instead of silently auto-upgrading via `GOTOOLCHAIN=auto`, and bounds the blast radius of future `tools` releases

## Test plan
- [ ] CI green
- [ ] A downstream `datadog-api-spec` PR's `test-go-legacy-package / pre-commit / pre-commit` job passes once it bumps `reusable-ci.yml` SHA to a commit including this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)