### PR TITLE
Fix nullable UUID type mismatch in Go code generator

### DIFF
--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -155,7 +155,7 @@ def simple_type(schema, render_nullable=False, render_new=False):
             "date": "time.Time" if not nullable else f"{nullable_prefix}Time",
             "date-time": "time.Time" if not nullable else f"{nullable_prefix}Time",
             "binary": "_io.Reader",
-            "uuid": "uuid.UUID" if not nullable else f"{nullable_prefix}String",
+            "uuid": "uuid.UUID" if not nullable else f"{nullable_prefix}UUID",
         }.get(type_format, "string" if not nullable else f"{nullable_prefix}String")
     if type_name == "boolean":
         return "bool" if not nullable else f"{nullable_prefix}Bool"

--- a/.generator/src/generator/templates/utils.j2
+++ b/.generator/src/generator/templates/utils.j2
@@ -39,6 +39,50 @@ func PtrTime(v time.Time) *time.Time { return &v }
 // PtrUUID is helper routine that returns a pointer to given UUID value.
 func PtrUUID(v uuid.UUID) *uuid.UUID { return &v }
 
+// NullableUUID is a struct to hold a nullable UUID value.
+type NullableUUID struct {
+	value *uuid.UUID
+	isSet bool
+}
+
+// Get returns the value associated with the nullable UUID.
+func (v NullableUUID) Get() *uuid.UUID {
+	return v.value
+}
+
+// Set sets the value associated with the nullable UUID.
+func (v *NullableUUID) Set(val *uuid.UUID) {
+	v.value = val
+	v.isSet = true
+}
+
+// IsSet returns true if the value has been set.
+func (v NullableUUID) IsSet() bool {
+	return v.isSet
+}
+
+// Unset resets fields of the nullable UUID.
+func (v *NullableUUID) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+// NewNullableUUID instantiates a new nullable UUID.
+func NewNullableUUID(val *uuid.UUID) *NullableUUID {
+	return &NullableUUID{value: val, isSet: true}
+}
+
+// MarshalJSON serializes the associated value.
+func (v NullableUUID) MarshalJSON() ([]byte, error) {
+	return Marshal(v.value)
+}
+
+// UnmarshalJSON deserializes to the associated value.
+func (v *NullableUUID) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return Unmarshal(src, &v.value)
+}
+
 // PaginationResult pagination item helper struct
 type PaginationResult[T any] struct {
 	Item T

--- a/api/datadog/utils.go
+++ b/api/datadog/utils.go
@@ -43,6 +43,50 @@ func PtrTime(v time.Time) *time.Time { return &v }
 // PtrUUID is helper routine that returns a pointer to given UUID value.
 func PtrUUID(v uuid.UUID) *uuid.UUID { return &v }
 
+// NullableUUID is a struct to hold a nullable UUID value.
+type NullableUUID struct {
+	value *uuid.UUID
+	isSet bool
+}
+
+// Get returns the value associated with the nullable UUID.
+func (v NullableUUID) Get() *uuid.UUID {
+	return v.value
+}
+
+// Set sets the value associated with the nullable UUID.
+func (v *NullableUUID) Set(val *uuid.UUID) {
+	v.value = val
+	v.isSet = true
+}
+
+// IsSet returns true if the value has been set.
+func (v NullableUUID) IsSet() bool {
+	return v.isSet
+}
+
+// Unset resets fields of the nullable UUID.
+func (v *NullableUUID) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+// NewNullableUUID instantiates a new nullable UUID.
+func NewNullableUUID(val *uuid.UUID) *NullableUUID {
+	return &NullableUUID{value: val, isSet: true}
+}
+
+// MarshalJSON serializes the associated value.
+func (v NullableUUID) MarshalJSON() ([]byte, error) {
+	return Marshal(v.value)
+}
+
+// UnmarshalJSON deserializes to the associated value.
+func (v *NullableUUID) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return Unmarshal(src, &v.value)
+}
+
 // PaginationResult pagination item helper struct
 type PaginationResult[T any] struct {
 	Item  T


### PR DESCRIPTION
## Summary

- Nullable UUID fields (`format: uuid` + `nullable: true`) were being mapped to `NullableString` in `formatter.py`, causing generated getter/setter methods to return `*string` while the method signatures expected `uuid.UUID` — resulting in compile errors.
- Added a dedicated `NullableUUID` struct to `utils.j2` (matching the pattern of `NullableBool`, `NullableString`, `NullableTime`, etc.).
- Updated `formatter.py` line 158 to emit `NullableUUID` / `NewNullableUUID` for nullable uuid fields instead of `NullableString`.

**Example compile errors this fixes** (from `datadog-api-spec` PR #5821 CI run):
```
model_incident_rule_data_attributes_request.go:191: cannot use *o.IncidentTypeUuid.Get() (variable of type string) as uuid.UUID value in return statement
model_incident_rule_data_attributes_request.go:201: cannot use o.IncidentTypeUuid.Get() (value of type *string) as *uuid.UUID value in return statement
model_incident_rule_data_attributes_request.go:211: cannot use &v (value of type *uuid.UUID) as *string value in argument to o.IncidentTypeUuid.Set
```

## Test plan

- [ ] Regenerate client with a spec that contains a nullable uuid field and confirm the generated code compiles without type errors.
- [ ] Confirm `NullableUUID` marshal/unmarshal round-trips correctly (JSON UUID strings ↔ `uuid.UUID`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)