### PR TITLE
feat(auth): add web identity token credential fallback for AWS WIF

### DIFF
--- a/api/datadog/aws.go
+++ b/api/datadog/aws.go
@@ -5,14 +5,18 @@
 package datadog
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -41,9 +45,13 @@ const (
 	applicationForm = "application/x-www-form-urlencoded; charset=utf-8"
 
 	// AWS specific constants
-	AWSAccessKeyIdName     = "AWS_ACCESS_KEY_ID"
-	AWSSecretAccessKeyName = "AWS_SECRET_ACCESS_KEY"
-	AWSSessionTokenName    = "AWS_SESSION_TOKEN"
+	AWSAccessKeyIdName          = "AWS_ACCESS_KEY_ID"
+	AWSSecretAccessKeyName      = "AWS_SECRET_ACCESS_KEY"
+	AWSSessionTokenName         = "AWS_SESSION_TOKEN"
+	AWSWebIdentityTokenFileEnvVar = "AWS_WEB_IDENTITY_TOKEN_FILE"
+	AWSRoleARNEnvVar              = "AWS_ROLE_ARN"
+	AWSRoleSessionNameEnvVar      = "AWS_ROLE_SESSION_NAME"
+	defaultRoleSessionName        = "datadog-api-client"
 
 	amzDateHeader         = "X-Amz-Date"
 	amzTokenHeader        = "X-Amz-Security-Token"
@@ -62,6 +70,8 @@ const ProviderAWS = "aws"
 
 type AWSAuth struct {
 	AwsRegion string
+	// stsEndpointOverride overrides the STS endpoint URL; used in tests.
+	stsEndpointOverride string
 }
 
 func (a *AWSAuth) Authenticate(ctx context.Context, config *DelegatedTokenConfig) (*DelegatedTokenCredentials, error) {
@@ -100,19 +110,111 @@ func (a *AWSAuth) GetCredentials(ctx context.Context) *Credentials {
 			creds.SessionToken = sessionToken
 		}
 		return &creds
-	} else {
-		accessKey := os.Getenv(AWSAccessKeyIdName)
-		secretKey := os.Getenv(AWSSecretAccessKeyName)
-		sessionToken := os.Getenv(AWSSessionTokenName)
+	}
+
+	accessKey := os.Getenv(AWSAccessKeyIdName)
+	secretKey := os.Getenv(AWSSecretAccessKeyName)
+	sessionToken := os.Getenv(AWSSessionTokenName)
+	if sessionToken != "" {
 		return &Credentials{
 			AccessKeyID:     accessKey,
 			SecretAccessKey: secretKey,
 			SessionToken:    sessionToken,
 		}
 	}
+
+	// Fall back to web identity token exchange (covers TFE dynamic credentials, IRSA, etc.)
+	if creds, err := a.assumeRoleWithWebIdentity(ctx); err == nil {
+		return creds
+	}
+
+	return &Credentials{
+		AccessKeyID:     accessKey,
+		SecretAccessKey: secretKey,
+		SessionToken:    sessionToken,
+	}
+}
+
+type stsCredentials struct {
+	AccessKeyId     string `xml:"AccessKeyId"`
+	SecretAccessKey string `xml:"SecretAccessKey"`
+	SessionToken    string `xml:"SessionToken"`
+}
+
+type stsAssumeRoleWithWebIdentityResponse struct {
+	Result struct {
+		Credentials stsCredentials `xml:"Credentials"`
+	} `xml:"AssumeRoleWithWebIdentityResult"`
+}
+
+func (a *AWSAuth) assumeRoleWithWebIdentity(ctx context.Context) (*Credentials, error) {
+	tokenFile := os.Getenv(AWSWebIdentityTokenFileEnvVar)
+	roleARN := os.Getenv(AWSRoleARNEnvVar)
+	if tokenFile == "" || roleARN == "" {
+		return nil, fmt.Errorf("web identity env vars not set")
+	}
+
+	tokenBytes, err := os.ReadFile(tokenFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read web identity token file: %w", err)
+	}
+
+	sessionName := os.Getenv(AWSRoleSessionNameEnvVar)
+	if sessionName == "" {
+		sessionName = defaultRoleSessionName
+	}
+
+	stsURL, _, _ := a.getConnectionParameters()
+
+	params := url.Values{}
+	params.Set("Action", "AssumeRoleWithWebIdentity")
+	params.Set("Version", "2011-06-15")
+	params.Set("RoleArn", roleARN)
+	params.Set("WebIdentityToken", string(tokenBytes))
+	params.Set("RoleSessionName", sessionName)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, stsURL, strings.NewReader(params.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create STS request: %w", err)
+	}
+	req.Header.Set(contentTypeHeader, applicationForm)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("STS request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read STS response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("STS AssumeRoleWithWebIdentity returned status %d", resp.StatusCode)
+	}
+
+	var result stsAssumeRoleWithWebIdentityResponse
+	if err := xml.NewDecoder(bytes.NewReader(body)).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to parse STS response: %w", err)
+	}
+
+	creds := result.Result.Credentials
+	if creds.AccessKeyId == "" || creds.SessionToken == "" {
+		return nil, fmt.Errorf("STS response missing credentials")
+	}
+
+	return &Credentials{
+		AccessKeyID:     creds.AccessKeyId,
+		SecretAccessKey: creds.SecretAccessKey,
+		SessionToken:    creds.SessionToken,
+	}, nil
 }
 
 func (a *AWSAuth) getConnectionParameters() (string, string, string) {
+	if a.stsEndpointOverride != "" {
+		return a.stsEndpointOverride, defaultRegion, defaultStsHost
+	}
 	region := a.AwsRegion
 	var host string
 	// Default to the default global STS Host (see here: https://docs.aws.amazon.com/general/latest/gr/sts.html)

--- a/api/datadog/aws.go
+++ b/api/datadog/aws.go
@@ -68,6 +68,18 @@ const (
 
 const ProviderAWS = "aws"
 
+// AWSWebIdentityVariables holds explicit web identity token configuration for use with
+// ContextAWSWebIdentityVariables. When set, GetCredentials will call AssumeRoleWithWebIdentity
+// using these values instead of reading from AWS_WEB_IDENTITY_TOKEN_FILE / AWS_ROLE_ARN env vars.
+type AWSWebIdentityVariables struct {
+	// TokenFile is the path to the OIDC web identity token file.
+	TokenFile string
+	// RoleARN is the ARN of the IAM role to assume.
+	RoleARN string
+	// RoleSessionName is an optional session name; defaults to "datadog-api-client".
+	RoleSessionName string
+}
+
 type AWSAuth struct {
 	AwsRegion string
 	// stsEndpointOverride overrides the STS endpoint URL; used in tests.
@@ -96,8 +108,8 @@ func (a *AWSAuth) Authenticate(ctx context.Context, config *DelegatedTokenConfig
 }
 
 func (a *AWSAuth) GetCredentials(ctx context.Context) *Credentials {
-	keys := ctx.Value(ContextAWSVariables)
-	if keys != nil {
+	// 1. Explicit static credentials via context.
+	if keys := ctx.Value(ContextAWSVariables); keys != nil {
 		keysMap := keys.(map[string]string)
 		creds := Credentials{}
 		if accessKey, ok := keysMap[AWSAccessKeyIdName]; ok {
@@ -112,6 +124,15 @@ func (a *AWSAuth) GetCredentials(ctx context.Context) *Credentials {
 		return &creds
 	}
 
+	// 2. Explicit web identity config via context — authoritative; failure is terminal, not a
+	// fallthrough. Silently falling back to env-var creds when an explicit config fails would
+	// authenticate as a different identity than the caller intended.
+	if wiv, ok := ctx.Value(ContextAWSWebIdentityVariables).(AWSWebIdentityVariables); ok {
+		creds, _ := a.assumeRoleWithWebIdentity(ctx, wiv.TokenFile, wiv.RoleARN, wiv.RoleSessionName)
+		return creds
+	}
+
+	// 3. Static credentials from environment variables.
 	accessKey := os.Getenv(AWSAccessKeyIdName)
 	secretKey := os.Getenv(AWSSecretAccessKeyName)
 	sessionToken := os.Getenv(AWSSessionTokenName)
@@ -123,8 +144,8 @@ func (a *AWSAuth) GetCredentials(ctx context.Context) *Credentials {
 		}
 	}
 
-	// Fall back to web identity token exchange (covers TFE dynamic credentials, IRSA, etc.)
-	if creds, err := a.assumeRoleWithWebIdentity(ctx); err == nil {
+	// 4. Web identity token exchange from environment variables (TFE dynamic credentials, IRSA, etc.).
+	if creds, err := a.assumeRoleWithWebIdentity(ctx, os.Getenv(AWSWebIdentityTokenFileEnvVar), os.Getenv(AWSRoleARNEnvVar), os.Getenv(AWSRoleSessionNameEnvVar)); err == nil {
 		return creds
 	}
 
@@ -147,11 +168,9 @@ type stsAssumeRoleWithWebIdentityResponse struct {
 	} `xml:"AssumeRoleWithWebIdentityResult"`
 }
 
-func (a *AWSAuth) assumeRoleWithWebIdentity(ctx context.Context) (*Credentials, error) {
-	tokenFile := os.Getenv(AWSWebIdentityTokenFileEnvVar)
-	roleARN := os.Getenv(AWSRoleARNEnvVar)
+func (a *AWSAuth) assumeRoleWithWebIdentity(ctx context.Context, tokenFile, roleARN, sessionName string) (*Credentials, error) {
 	if tokenFile == "" || roleARN == "" {
-		return nil, fmt.Errorf("web identity env vars not set")
+		return nil, fmt.Errorf("web identity token file or role ARN not set")
 	}
 
 	tokenBytes, err := os.ReadFile(tokenFile)
@@ -159,7 +178,6 @@ func (a *AWSAuth) assumeRoleWithWebIdentity(ctx context.Context) (*Credentials, 
 		return nil, fmt.Errorf("failed to read web identity token file: %w", err)
 	}
 
-	sessionName := os.Getenv(AWSRoleSessionNameEnvVar)
 	if sessionName == "" {
 		sessionName = defaultRoleSessionName
 	}

--- a/api/datadog/aws_test.go
+++ b/api/datadog/aws_test.go
@@ -1,0 +1,134 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const stsWebIdentityResponse = `<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithWebIdentityResult>
+    <Credentials>
+      <AccessKeyId>ASIAIOSFODNN7EXAMPLE</AccessKeyId>
+      <SecretAccessKey>wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY</SecretAccessKey>
+      <SessionToken>AQoXnyc4lcK4w4OIWen8ORnVZYIkFuyfAc/EXAMPLE</SessionToken>
+      <Expiration>2026-06-09T23:00:00Z</Expiration>
+    </Credentials>
+  </AssumeRoleWithWebIdentityResult>
+  <ResponseMetadata>
+    <RequestId>ad4156e9-bce1-11e2-82e6-6b6efEXAMPLE</RequestId>
+  </ResponseMetadata>
+</AssumeRoleWithWebIdentityResponse>`
+
+func TestGetCredentials_EnvVars(t *testing.T) {
+	t.Setenv(AWSAccessKeyIdName, "AKIAIOSFODNN7EXAMPLE")
+	t.Setenv(AWSSecretAccessKeyName, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY")
+	t.Setenv(AWSSessionTokenName, "token123")
+
+	a := &AWSAuth{}
+	creds := a.GetCredentials(context.Background())
+
+	if creds.AccessKeyID != "AKIAIOSFODNN7EXAMPLE" {
+		t.Errorf("unexpected AccessKeyID: %s", creds.AccessKeyID)
+	}
+	if creds.SessionToken != "token123" {
+		t.Errorf("unexpected SessionToken: %s", creds.SessionToken)
+	}
+}
+
+func TestGetCredentials_WebIdentity(t *testing.T) {
+	// Spin up a mock STS server
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("Action") != "AssumeRoleWithWebIdentity" {
+			http.Error(w, "unexpected action", http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("WebIdentityToken") != "test-oidc-token" {
+			http.Error(w, "unexpected token", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "text/xml")
+		fmt.Fprint(w, stsWebIdentityResponse)
+	}))
+	defer srv.Close()
+
+	// Write a temp token file
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenFile, []byte("test-oidc-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(AWSWebIdentityTokenFileEnvVar, tokenFile)
+	t.Setenv(AWSRoleARNEnvVar, "arn:aws:iam::123456789012:role/TestRole")
+	// Clear static creds so we fall through to web identity
+	t.Setenv(AWSAccessKeyIdName, "")
+	t.Setenv(AWSSecretAccessKeyName, "")
+	t.Setenv(AWSSessionTokenName, "")
+
+	// Point the auth at our mock STS server
+	a := &AWSAuth{stsEndpointOverride: srv.URL}
+	creds := a.GetCredentials(context.Background())
+
+	if creds.AccessKeyID != "ASIAIOSFODNN7EXAMPLE" {
+		t.Errorf("unexpected AccessKeyID: %s", creds.AccessKeyID)
+	}
+	if creds.SessionToken != "AQoXnyc4lcK4w4OIWen8ORnVZYIkFuyfAc/EXAMPLE" {
+		t.Errorf("unexpected SessionToken: %s", creds.SessionToken)
+	}
+}
+
+func TestGetCredentials_WebIdentityMissingEnvVars(t *testing.T) {
+	t.Setenv(AWSAccessKeyIdName, "")
+	t.Setenv(AWSSecretAccessKeyName, "")
+	t.Setenv(AWSSessionTokenName, "")
+	t.Setenv(AWSWebIdentityTokenFileEnvVar, "")
+	t.Setenv(AWSRoleARNEnvVar, "")
+
+	a := &AWSAuth{}
+	creds := a.GetCredentials(context.Background())
+
+	// Should return empty credentials without panicking
+	if creds == nil {
+		t.Fatal("expected non-nil credentials")
+	}
+	if creds.SessionToken != "" {
+		t.Errorf("expected empty session token, got: %s", creds.SessionToken)
+	}
+}
+
+func TestGetCredentials_ContextOverridesWebIdentity(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenFile, []byte("should-not-be-used"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(AWSWebIdentityTokenFileEnvVar, tokenFile)
+	t.Setenv(AWSRoleARNEnvVar, "arn:aws:iam::123456789012:role/TestRole")
+
+	ctx := context.WithValue(context.Background(), ContextAWSVariables, map[string]string{
+		AWSAccessKeyIdName:     "EXPLICIT_KEY",
+		AWSSecretAccessKeyName: "EXPLICIT_SECRET",
+		AWSSessionTokenName:    "EXPLICIT_TOKEN",
+	})
+
+	a := &AWSAuth{}
+	creds := a.GetCredentials(ctx)
+
+	if creds.AccessKeyID != "EXPLICIT_KEY" {
+		t.Errorf("context credentials should take precedence, got: %s", creds.AccessKeyID)
+	}
+	if creds.SessionToken != "EXPLICIT_TOKEN" {
+		t.Errorf("context credentials should take precedence, got: %s", creds.SessionToken)
+	}
+}

--- a/api/datadog/configuration.go
+++ b/api/datadog/configuration.go
@@ -48,6 +48,12 @@ var (
 	// ContextAWSVariables takes AWS credentials as authentication for the request.
 	ContextAWSVariables = contextKey("awsVariables")
 
+	// ContextAWSWebIdentityVariables takes an AWSWebIdentityVariables to authenticate
+	// via web identity token exchange (AssumeRoleWithWebIdentity) rather than static credentials.
+	// Takes precedence over AWS_WEB_IDENTITY_TOKEN_FILE / AWS_ROLE_ARN environment variables
+	// but is lower priority than ContextAWSVariables.
+	ContextAWSWebIdentityVariables = contextKey("awsWebIdentityVariables")
+
 	// ContextHttpSignatureAuth takes HttpSignatureAuth as authentication for the request.
 	ContextHttpSignatureAuth = contextKey("httpsignature")
 


### PR DESCRIPTION
## Summary

- The AWS credential reader in `GetCredentials` only checked three static env vars (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`). Environments that use web identity federation — Terraform Enterprise dynamic provider credentials, EKS IRSA, or any OIDC-based workload identity setup — inject credentials via `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN` instead. These were silently ignored, resulting in a `"missing AWS credentials"` error before any network call was made.
- Add a fallback in `GetCredentials`: when `AWS_SESSION_TOKEN` is absent, check for `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN` and exchange the token for STS credentials via `AssumeRoleWithWebIdentity`. The existing static env var path and `ContextAWSVariables` override are both unchanged.
- No new dependencies — implementation uses only stdlib (`net/http`, `encoding/xml`, `os`).

## Changes

**`api/datadog/aws.go`**
- Added `stsEndpointOverride` field to `AWSAuth` (unexported, for test injection only)
- Added `assumeRoleWithWebIdentity` which reads the token file and calls STS directly
- Updated `GetCredentials` to fall through to web identity when session token env var is absent
- Added constants for `AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_ROLE_ARN`, `AWS_ROLE_SESSION_NAME`

**`api/datadog/aws_test.go`** (new)
- `TestGetCredentials_EnvVars` — static env var path still works
- `TestGetCredentials_WebIdentity` — web identity exchange against a mock STS server
- `TestGetCredentials_WebIdentityMissingEnvVars` — graceful fallback when no credentials at all
- `TestGetCredentials_ContextOverridesWebIdentity` — explicit context takes precedence over env vars

## Test plan

- [ ] `go test ./api/datadog/ -run TestGetCredentials` passes (all 4 cases)
- [ ] Existing behaviour unchanged: `ContextAWSVariables` and static env vars continue to work as before
- [ ] Verify with a TFE workspace configured with dynamic provider credentials targeting an IAM role

🤖 Generated with [Claude Code](https://claude.com/claude-code)