### PR TITLE
Fix empty UnmarshalJSON generated for oneOf with discriminator

### DIFF
--- a/.generator/src/generator/templates/model_oneof.j2
+++ b/.generator/src/generator/templates/model_oneof.j2
@@ -25,37 +25,29 @@ func {{ attributeName }}As{{ name }}(v {% if not isAdditionalPropertiesContainer
 // UnmarshalJSON turns data into one of the pointers in the struct.
 func (obj *{{ name }}) UnmarshalJSON(data []byte) error {
 	var err error
-{#-
-	{{#useOneOfDiscriminatorLookup}}
-	{{#discriminator}}
-	{{#mappedModels}}
-	{{#-first}}
+{%- if model.discriminator is defined %}
 	// use discriminator value to speed up the lookup
 	var jsonDict map[string]interface{}
 	err = datadog.Unmarshal(data, &jsonDict)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal JSON into map for the discriminator lookup.")
 	}
-
-	{{/-first}}
-	// check if the discriminator value is '{{{mappingName}}}'
-	if jsonDict["{{{propertyBaseName}}}"] == "{{{mappingName}}}" {
-		// try to unmarshal JSON data into {{{modelName}}}
-		err = datadog.Unmarshal(data, &obj.{{{modelName}}})
+{%- for mappingValue, ref in model.discriminator.get("mapping", {}).items() %}
+{%- set modelName = ref.split("/")[-1] %}
+	// check if the discriminator value is '{{ mappingValue }}'
+	if jsonDict["{{ model.discriminator.propertyName }}"] == "{{ mappingValue }}" {
+		// try to unmarshal JSON data into {{ modelName }}
+		err = datadog.Unmarshal(data, &obj.{{ modelName }})
 		if err == nil {
-			return nil // data stored in obj.{{{modelName}}}, return on the first match
+			return nil // data stored in obj.{{ modelName }}, return on the first match
 		} else {
-			obj.{{{modelName}}} = nil
-			return fmt.Errorf("failed to unmarshal {{ name }} as {{{modelName}}}: %s", err.Error())
+			obj.{{ modelName }} = nil
+			return fmt.Errorf("failed to unmarshal {{ name }} as {{ modelName }}: %s", err.Error())
 		}
 	}
-
-	{{/mappedModels}}
-	{{/discriminator}}
+{%- endfor %}
 	return nil
-	{{/useOneOfDiscriminatorLookup}}
--#}
-{%- if not (model.discriminator is defined) %}
+{%- else %}
 	match := 0
 {%- for oneOf in model.oneOf %}
 	{%- set dataType = get_type(oneOf) %}
@@ -87,7 +79,7 @@ func (obj *{{ name }}) UnmarshalJSON(data []byte) error {
 		return datadog.Unmarshal(data, &obj.UnparsedObject)
 	}
 	return nil // exactly one match
-	{%- endif %}
+{%- endif %}
 }
 
 // MarshalJSON turns data from the first non-nil pointers in the struct to JSON.


### PR DESCRIPTION
### What does this PR do?

When a oneOf schema has a discriminator, the generator was producing an empty `UnmarshalJSON` body, causing Go compile errors (`declared and not used: err` and `missing return`).

The root cause was that the old Mustache-style discriminator logic had been commented out using Jinja2 comment syntax (`{#- ... -#}`), and the replacement Jinja2 block was guarded with `{%- if not (model.discriminator is defined) %}`, so neither path ran when a discriminator was present.

The fix adds a proper `{%- else %}` branch that iterates over the discriminator's `mapping` dict and generates discriminator-based lookup logic, matching the intent of the original commented-out Mustache code. The non-discriminator path is unchanged.

### Additional Notes

Triggered by [DataDog/datadog-api-spec#5917](https://github.com/DataDog/datadog-api-spec/pull/5917), which introduces a `oneOf` + discriminator on `DeploymentGatesEvaluationRule` and produced the broken auto-generated PR [#4225](https://github.com/DataDog/datadog-api-client-go/pull/4225) where the compile errors are visible.

The fix was verified by running the generator locally against the spec from that PR. With the fix applied, the generator produces a correct `UnmarshalJSON` that reads the `type` discriminator field and dispatches to the right struct. Running `go build ./api/datadogV2/...` against the output compiled cleanly.

UnmarshalJSON shape after running generator locally for changes in https://github.com/DataDog/datadog-api-spec/pull/5917:
```go
  func (obj *DeploymentGatesEvaluationRule) UnmarshalJSON(data []byte) error {
      var err error
      var jsonDict map[string]interface{}
      err = datadog.Unmarshal(data, &jsonDict)
      if err != nil {
          return fmt.Errorf("failed to unmarshal JSON into map for the discriminator lookup.")
      }
      if jsonDict["type"] == "faulty_deployment_detection" {
          err = datadog.Unmarshal(data, &obj.DeploymentGatesFDDRule)
          if err == nil {
              return nil
          } else {
              obj.DeploymentGatesFDDRule = nil
              return fmt.Errorf("failed to unmarshal DeploymentGatesEvaluationRule as DeploymentGatesFDDRule: %s", err.Error())
          }
      }
      if jsonDict["type"] == "monitor" {
          err = datadog.Unmarshal(data, &obj.DeploymentGatesMonitorRule)
          if err == nil {
              return nil
          } else {
              obj.DeploymentGatesMonitorRule = nil
              return fmt.Errorf("failed to unmarshal DeploymentGatesEvaluationRule as DeploymentGatesMonitorRule: %s", err.Error())
          }
      }
      return nil
  }

```

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.
- [x] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.