### PR TITLE
Fix generated oneOf examples for array aliases

### DIFF
--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -369,7 +369,10 @@ def _format_oneof(schema, data, name, name_prefix, replace_values, required, nul
     reference = "" if required or nullable else "&"
     if name:
         if one_of_schema.get("type") == "array":
-            parameters = f"&{parameters}"
+            if one_of_schema.get("x-generate-alias-as-model"):
+                parameters = f"&{name_prefix}{one_of_schema_name}{{Items: {parameters}}}"
+            else:
+                parameters = f"&{parameters}"
         return f"{reference}{name_prefix}{name}{{\n{one_of_schema_name}: {parameters}}}"
     if one_of_schema.get("type") == "array":
         reference = "&"

--- a/.generator/tests/test_formatter.py
+++ b/.generator/tests/test_formatter.py
@@ -84,6 +84,47 @@ class TestFormatDataWithSchemaArrayItems:
         assert "StringMapItem" not in result
         assert "map[string]string" in result
 
+    def test_named_array_alias_in_oneof_uses_generated_wrapper(self):
+        message_schema = SchemaWithRef(
+            {
+                "type": "object",
+                "properties": {
+                    "role": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+                "required": ["role", "content"],
+            },
+            ref="#/components/schemas/LLMObsPromptChatMessage",
+        )
+        chat_schema = SchemaWithRef(
+            {
+                "type": "array",
+                "items": message_schema,
+                "x-generate-alias-as-model": True,
+            },
+            ref="#/components/schemas/LLMObsPromptChatTemplate",
+        )
+        template_schema = SchemaWithRef(
+            {"oneOf": [{"type": "string"}, chat_schema]},
+            ref="#/components/schemas/LLMObsPromptTemplate",
+        )
+
+        result = format_data_with_schema(
+            [
+                {"role": "system", "content": "You help {{company_name}} customers."},
+                {"role": "user", "content": "Answer {{question}}"},
+            ],
+            template_schema,
+            name_prefix="datadogV2.",
+            required=True,
+        )
+
+        assert (
+            "LLMObsPromptChatTemplate: &datadogV2.LLMObsPromptChatTemplate{Items: "
+            "[]datadogV2.LLMObsPromptChatMessage{" in result
+        )
+        assert "LLMObsPromptChatTemplate: &[]datadogV2.LLMObsPromptChatMessage{" not in result
+
 
 class TestNullableInlineObjectWithNullValue:
     """Nullable inline (anonymous) object schemas must return 'nil' when data is None."""


### PR DESCRIPTION
## What changed

When a `oneOf` selects an array schema generated as a named model, format the example using that generated wrapper and its `Items` field instead of assigning a raw slice to the union member.

The change is limited to array branches carrying `x-generate-alias-as-model`; ordinary array branches keep their existing output.

## Why

This was discovered while adding realistic chat-template examples to [DataDog/datadog-api-spec#6113](https://github.com/DataDog/datadog-api-spec/pull/6113). The prompt template is a `oneOf` between a string and the named `LLMObsPromptChatTemplate` array alias.

The generator produced code equivalent to:

```go
LLMObsPromptChatTemplate: &[]datadogV2.LLMObsPromptChatMessage{...}
```

but the generated union field expects `*datadogV2.LLMObsPromptChatTemplate`. This caused the generated chat example to fail compilation and forced the spec example to use the text branch.

The generated expression is now equivalent to:

```go
LLMObsPromptChatTemplate: &datadogV2.LLMObsPromptChatTemplate{
    Items: []datadogV2.LLMObsPromptChatMessage{...},
}
```

## Validation

Added a focused regression test using the same string-or-chat-array schema shape and realistic system/user messages with template variables. It asserts the named wrapper is generated and the previous invalid raw-slice assignment is absent.