### PR TITLE
Use generated BDD test artifacts

### DIFF
--- a/run-bdd-tests.sh
+++ b/run-bdd-tests.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 && pwd -P)"
+TEST_ARTIFACTS=${BDD_TEST_ARTIFACTS:-${REPO_ROOT}/tests/generated}
+
+if [ ! -x "${TEST_ARTIFACTS}/test-server" ]; then
+    echo "Generated test server not found at ${TEST_ARTIFACTS}/test-server" >&2
+    exit 1
+fi
+if [ ! -f "${TEST_ARTIFACTS}/test-runner-data/manifest.json" ]; then
+    echo "Generated test runner manifest not found below ${TEST_ARTIFACTS}" >&2
+    exit 1
+fi
+
+TEST_SERVER_PID=""
+cleanup() {
+    if [ -n "${TEST_SERVER_PID}" ]; then
+        kill "${TEST_SERVER_PID}" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+TEST_SERVER_PORT=${BDD_TEST_SERVER_PORT:-18084}
+TEST_SERVER_LOG=${BDD_TEST_SERVER_LOG:-${TMPDIR:-/tmp}/datadog-go-test-server.log}
+"${TEST_ARTIFACTS}/test-server" --port "${TEST_SERVER_PORT}" >"${TEST_SERVER_LOG}" 2>&1 &
+TEST_SERVER_PID=$!
+for _ in {1..50}; do
+    if curl --silent --fail "http://127.0.0.1:${TEST_SERVER_PORT}/__openapi_transformer__/health" >/dev/null; then
+        break
+    fi
+    sleep 0.1
+done
+curl --silent --fail "http://127.0.0.1:${TEST_SERVER_PORT}/__openapi_transformer__/health" >/dev/null
+
+cd "${REPO_ROOT}/tests"
+BDD_FEATURES_ROOT="${TEST_ARTIFACTS}/test-runner-data/features" \
+DD_TEST_SERVER_URL="http://127.0.0.1:${TEST_SERVER_PORT}" \
+DD_TEST_RUNNER_DATA="${TEST_ARTIFACTS}/test-runner-data" \
+RECORD=false \
+go test ./scenarios "$@"

--- a/tests/scenarios/actions.go
+++ b/tests/scenarios/actions.go
@@ -136,6 +136,18 @@ func ConfigureClients(ctx context.Context, bddCTX gobdd.Context) (context.Contex
 	config := datadog.NewConfiguration()
 	config.Debug = debug
 	config.RetryConfiguration.EnableRetry = true
+	if testServerEnabled() {
+		server := datadog.ServerConfigurations{{URL: os.Getenv("DD_TEST_SERVER_URL")}}
+		config.Servers = server
+		for operation := range config.OperationServers {
+			config.OperationServers[operation] = server
+		}
+		session, _ := bddCTX.Get(testServerSessionKey{})
+		config.RetryConfiguration.EnableRetry = false
+		config.HTTPClient = &http.Client{
+			Transport: testServerTransport{session: session.(string)},
+		}
+	}
 	c := datadog.NewAPIClient(config)
 
 	ctx = context.WithValue(
@@ -144,22 +156,32 @@ func ConfigureClients(ctx context.Context, bddCTX gobdd.Context) (context.Contex
 		map[string]datadog.APIKey{},
 	)
 
-	ctx, err := tests.WithClock(ctx, tests.SecurePath(t.Name()))
-	if err != nil {
-		t.Fatalf("could not setup clock: %v", err)
-	}
+	if !testServerEnabled() {
+		var err error
+		ctx, err = tests.WithClock(ctx, tests.SecurePath(t.Name()))
+		if err != nil {
+			t.Fatalf("could not setup clock: %v", err)
+		}
 
-	r, err := tests.Recorder(ctx, tests.SecurePath(t.Name()))
-	if err != nil {
-		t.Fatalf("could not setup recorder: %v", err)
+		r, err := tests.Recorder(ctx, tests.SecurePath(t.Name()))
+		if err != nil {
+			t.Fatalf("could not setup recorder: %v", err)
+		}
+		httpClient := http.Client{Transport: tests.WrapRoundTripper(r)}
+		c.GetConfig().HTTPClient = &httpClient
+		client := reflect.ValueOf(c)
+		bddCTX.Set(clientKeys{}, client)
+		return ctx, func() {
+			r.Stop()
+		}
 	}
-	httpClient := http.Client{Transport: tests.WrapRoundTripper(r)}
-	c.GetConfig().HTTPClient = &httpClient
 
 	client := reflect.ValueOf(c)
 	bddCTX.Set(clientKeys{}, client)
 	return ctx, func() {
-		r.Stop()
+		if err := stopTestServerSession(bddCTX); err != nil {
+			t.Error(err)
+		}
 	}
 }
 
@@ -230,7 +252,7 @@ func (s GivenStep) RegisterSuite(suite *gobdd.Suite, version string) {
 		responseJSON, _ := toJSON(result[0])
 
 		if undo != nil {
-			GetCleanup(ctx)[fmt.Sprintf("00-given-%s", s.Key)] = undo(result)
+			GetCleanup(ctx)[fmt.Sprintf("%03d-given-%s", len(GetCleanup(ctx)), s.Key)] = undo(result)
 		}
 
 		if s.Source != nil {

--- a/tests/scenarios/scenarios.go
+++ b/tests/scenarios/scenarios.go
@@ -392,6 +392,7 @@ func RunCleanup(ctx gobdd.Context) {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
+	sort.Sort(sort.Reverse(sort.StringSlice(keys)))
 
 	for _, name := range keys {
 		cc[name]()

--- a/tests/scenarios/scenarios_test.go
+++ b/tests/scenarios/scenarios_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/tests"
 	ddtesting "github.com/DataDog/dd-sdk-go-testing"
 	msgs "github.com/cucumber/messages-go/v12"
 	"github.com/go-bdd/gobdd"
@@ -51,9 +52,13 @@ func TestScenarios(t *testing.T) {
 	}
 	for _, version := range []string{"v1", "v2"} {
 		t.Run(version, func(t *testing.T) {
+			featuresRoot := "features"
+			if root := os.Getenv("BDD_FEATURES_ROOT"); root != "" {
+				featuresRoot = root
+			}
 			s := gobdd.NewSuite(
 				t,
-				gobdd.WithFeaturesPath(fmt.Sprintf("features/%s/*.feature", version)),
+				gobdd.WithFeaturesPath(fmt.Sprintf("%s/%s/*.feature", featuresRoot, version)),
 				gobdd.WithTags(bddTags...),
 				gobdd.WithIgnoredTags(GetIgnoredTags()...),
 				gobdd.WithBeforeScenario(func(ctx gobdd.Context) {
@@ -90,11 +95,18 @@ func TestScenarios(t *testing.T) {
 							tracer.Tag("test.codeowners", string(testCodeowners)),
 						),
 					)
+					if testServerEnabled() {
+						session, err := startTestServerSession(ctx, feature.Name, scenario.Name)
+						if err != nil {
+							tt.Fatal(err)
+						}
+						cctx = tests.WithClockAt(cctx, session.FrozenAt)
+					}
 					cctx, closeRecorder := ConfigureClients(cctx, ctx)
 					SetCtx(cctx, ctx)
 					SetRequestsUndo(ctx, requestsUndo)
 					SetData(ctx, make(map[string]interface{}))
-					SetCleanup(ctx, map[string]func(){"99-finish": func() {
+					SetCleanup(ctx, map[string]func(){"000-finish": func() {
 						closeRecorder()
 						closeSpan()
 					}})

--- a/tests/scenarios/step_definitions.go
+++ b/tests/scenarios/step_definitions.go
@@ -74,6 +74,13 @@ func enableOperations(t gobdd.StepTest, ctx gobdd.Context, name string) {
 
 // newRequest sets callable operation to requestKey{}
 func newRequest(t gobdd.StepTest, ctx gobdd.Context, name string) {
+	if testRunnerEnabled() {
+		return
+	}
+	newRequestNative(t, ctx, name)
+}
+
+func newRequestNative(t gobdd.StepTest, ctx gobdd.Context, name string) {
 	c, err := ctx.Get(apiKey{})
 	if err != nil {
 		t.Error(err)
@@ -106,6 +113,13 @@ func statusIs(t gobdd.StepTest, ctx gobdd.Context, expected int, text string) {
 }
 
 func addParameterFrom(t gobdd.StepTest, ctx gobdd.Context, name string, path string) {
+	if testRunnerEnabled() {
+		return
+	}
+	addParameterFromNative(t, ctx, name, path)
+}
+
+func addParameterFromNative(t gobdd.StepTest, ctx gobdd.Context, name string, path string) {
 	value, err := tests.LookupStringI(GetData(ctx), CamelToSnakeCase(path))
 	if err != nil {
 		t.Errorf("key %s in %+v: %v", path, GetData(ctx), err)
@@ -205,6 +219,13 @@ func addPathArgumentWithValue(t gobdd.StepTest, ctx gobdd.Context, param string,
 }
 
 func addParameterWithValue(t gobdd.StepTest, ctx gobdd.Context, param string, value string) {
+	if testRunnerEnabled() {
+		return
+	}
+	addParameterWithValueNative(t, ctx, param, value)
+}
+
+func addParameterWithValueNative(t gobdd.StepTest, ctx gobdd.Context, param string, value string) {
 	// Get request builder for the current scenario
 	request, _, err := getRequestBuilder(ctx)
 	if err != nil {
@@ -215,6 +236,7 @@ func addParameterWithValue(t gobdd.StepTest, ctx gobdd.Context, param string, va
 }
 
 func requestIsSent(t gobdd.StepTest, ctx gobdd.Context) {
+	applyTestRunnerPlan(t, ctx, false)
 	request, in, err := getRequestBuilder(ctx)
 	if err != nil {
 		t.Error(err)
@@ -233,6 +255,9 @@ func requestIsSent(t gobdd.StepTest, ctx gobdd.Context) {
 	result := request.Call(in)
 
 	ctx.Set(responseKey{}, result)
+	if err := markMainRequestComplete(ctx); err != nil {
+		t.Error(err)
+	}
 
 	// Report probable serialization errors
 	if len(result) > 1 {
@@ -272,11 +297,12 @@ func requestIsSent(t gobdd.StepTest, ctx gobdd.Context) {
 	}
 
 	if undo != nil {
-		GetCleanup(ctx)["01-undo"] = undo(result)
+		GetCleanup(ctx)[fmt.Sprintf("%03d-undo", len(GetCleanup(ctx)))] = undo(result)
 	}
 }
 
 func requestWithPaginationIsSent(t gobdd.StepTest, ctx gobdd.Context) {
+	applyTestRunnerPlan(t, ctx, true)
 	// use WithPagination method
 	newWithPagination, _ := ctx.GetString(requestNameKey{})
 	newWithPagination = newWithPagination + "WithPagination"
@@ -332,15 +358,24 @@ func requestWithPaginationIsSent(t gobdd.StepTest, ctx gobdd.Context) {
 		}
 	}
 	ctx.Set(jsonResponseKey{}, responseJSON)
+	if err := markMainRequestComplete(ctx); err != nil {
+		t.Error(err)
+	}
 }
 
 func body(t gobdd.StepTest, ctx gobdd.Context, body string) {
+	if testRunnerEnabled() {
+		return
+	}
 	GetRequestParameters(ctx)["body"] = Templated(t, GetData(ctx), body)
 	pathCount, _ := ctx.Get(pathParamCountKey{})
 	ctx.Set(pathParamCountKey{}, pathCount.(int)+1)
 }
 
 func bodyFromFile(t gobdd.StepTest, ctx gobdd.Context, bodyFile string) {
+	if testRunnerEnabled() {
+		return
+	}
 	version := GetVersion(ctx)
 	body, err := os.ReadFile(fmt.Sprintf("./features/%s/%s", version, bodyFile))
 	if err != nil {

--- a/tests/scenarios/test_runner.go
+++ b/tests/scenarios/test_runner.go
@@ -1,0 +1,304 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+package scenarios
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-bdd/gobdd"
+)
+
+const testRunnerTemplateKey = "$openapi_transformer_template"
+
+type testRunnerManifest struct {
+	Scenarios []struct {
+		Version  string `json:"version"`
+		Feature  string `json:"feature"`
+		Scenario string `json:"scenario"`
+		File     string `json:"file"`
+	} `json:"scenarios"`
+}
+
+type testRunnerPlan struct {
+	API         string `json:"api"`
+	OperationID string `json:"operation_id"`
+	Request     struct {
+		Body *struct {
+			Value interface{} `json:"value"`
+		} `json:"body"`
+		Parameters []struct {
+			Name     string `json:"name"`
+			In       string `json:"in"`
+			Required bool   `json:"required"`
+			Source   struct {
+				Type  string      `json:"type"`
+				Path  string      `json:"path"`
+				Value interface{} `json:"value"`
+			} `json:"source"`
+		} `json:"parameters"`
+		Pagination bool `json:"pagination"`
+	} `json:"request"`
+}
+
+type testServerSession struct {
+	Session  string    `json:"session"`
+	FrozenAt time.Time `json:"frozen_at"`
+}
+
+type testFeatureKey struct{}
+type testScenarioKey struct{}
+type testServerSessionKey struct{}
+
+func testRunnerEnabled() bool {
+	return os.Getenv("DD_TEST_RUNNER_DATA") != ""
+}
+
+func testServerEnabled() bool {
+	return os.Getenv("DD_TEST_SERVER_URL") != ""
+}
+
+func testServerRequest(endpoint string, payload interface{}, result interface{}) error {
+	var body io.Reader
+	if payload != nil {
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(encoded)
+	}
+	request, err := http.NewRequest(
+		http.MethodPost,
+		os.Getenv("DD_TEST_SERVER_URL")+"/__openapi_transformer__"+endpoint,
+		body,
+	)
+	if err != nil {
+		return err
+	}
+	if payload != nil {
+		request.Header.Set("content-type", "application/json")
+	}
+	request.Close = true
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("test server POST %s failed (%d): %s", endpoint, response.StatusCode, responseBody)
+	}
+	if result == nil {
+		return nil
+	}
+	return json.Unmarshal(responseBody, result)
+}
+
+func startTestServerSession(ctx gobdd.Context, feature string, scenario string) (testServerSession, error) {
+	ctx.Set(testFeatureKey{}, feature)
+	ctx.Set(testScenarioKey{}, scenario)
+	var session testServerSession
+	err := testServerRequest("/sessions", map[string]string{
+		"version":  GetVersion(ctx),
+		"feature":  feature,
+		"scenario": scenario,
+	}, &session)
+	if err == nil {
+		ctx.Set(testServerSessionKey{}, session.Session)
+	}
+	return session, err
+}
+
+func stopTestServerSession(ctx gobdd.Context) error {
+	value, err := ctx.Get(testServerSessionKey{})
+	if err != nil {
+		return nil
+	}
+	var result struct {
+		Complete          bool `json:"complete"`
+		Interactions      int  `json:"interactions"`
+		TotalInteractions int  `json:"total_interactions"`
+	}
+	if err := testServerRequest(fmt.Sprintf("/sessions/%s/stop", value.(string)), nil, &result); err != nil {
+		return err
+	}
+	if !result.Complete {
+		return fmt.Errorf(
+			"test server session consumed %d of %d interactions",
+			result.Interactions,
+			result.TotalInteractions,
+		)
+	}
+	return nil
+}
+
+func markMainRequestComplete(ctx gobdd.Context) error {
+	value, err := ctx.Get(testServerSessionKey{})
+	if err != nil {
+		return nil
+	}
+	return testServerRequest(
+		fmt.Sprintf("/sessions/%s/main-complete", value.(string)),
+		nil,
+		nil,
+	)
+}
+
+func loadTestRunnerPlan(ctx gobdd.Context) (*testRunnerPlan, error) {
+	root := os.Getenv("DD_TEST_RUNNER_DATA")
+	manifestBody, err := os.ReadFile(filepath.Join(root, "manifest.json"))
+	if err != nil {
+		return nil, err
+	}
+	var manifest testRunnerManifest
+	if err := json.Unmarshal(manifestBody, &manifest); err != nil {
+		return nil, err
+	}
+	feature, _ := ctx.Get(testFeatureKey{})
+	scenario, _ := ctx.Get(testScenarioKey{})
+	for _, item := range manifest.Scenarios {
+		if item.Version == GetVersion(ctx) && item.Feature == feature && item.Scenario == scenario {
+			planBody, err := os.ReadFile(filepath.Join(root, item.File))
+			if err != nil {
+				return nil, err
+			}
+			var plan testRunnerPlan
+			if err := json.Unmarshal(planBody, &plan); err != nil {
+				return nil, err
+			}
+			return &plan, nil
+		}
+	}
+	return nil, fmt.Errorf(
+		"generated request plan not found for %s/%s/%s",
+		GetVersion(ctx),
+		feature,
+		scenario,
+	)
+}
+
+func materializeTestRunnerValue(t gobdd.StepTest, ctx gobdd.Context, value interface{}) (interface{}, error) {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		if len(typed) == 1 {
+			if template, ok := typed[testRunnerTemplateKey].(string); ok {
+				rendered := Templated(t, GetData(ctx), template)
+				var result interface{}
+				if err := json.Unmarshal([]byte(rendered), &result); err != nil {
+					return nil, err
+				}
+				return result, nil
+			}
+		}
+		result := make(map[string]interface{}, len(typed))
+		for key, item := range typed {
+			materialized, err := materializeTestRunnerValue(t, ctx, item)
+			if err != nil {
+				return nil, err
+			}
+			result[key] = materialized
+		}
+		return result, nil
+	case []interface{}:
+		result := make([]interface{}, len(typed))
+		for index, item := range typed {
+			materialized, err := materializeTestRunnerValue(t, ctx, item)
+			if err != nil {
+				return nil, err
+			}
+			result[index] = materialized
+		}
+		return result, nil
+	case string:
+		return Templated(t, GetData(ctx), typed), nil
+	default:
+		return value, nil
+	}
+}
+
+func applyTestRunnerPlan(t gobdd.StepTest, ctx gobdd.Context, pagination bool) {
+	if !testRunnerEnabled() {
+		return
+	}
+	plan, err := loadTestRunnerPlan(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Request.Pagination != pagination {
+		t.Fatalf("generated request plan pagination mismatch")
+	}
+	anInstanceOf(t, ctx, plan.API)
+	newRequestNative(t, ctx, plan.OperationID)
+
+	applyParameter := func(parameter struct {
+		Name     string `json:"name"`
+		In       string `json:"in"`
+		Required bool   `json:"required"`
+		Source   struct {
+			Type  string      `json:"type"`
+			Path  string      `json:"path"`
+			Value interface{} `json:"value"`
+		} `json:"source"`
+	}) {
+		if parameter.Source.Type == "fixture" {
+			addParameterFromNative(t, ctx, parameter.Name, parameter.Source.Path)
+			return
+		}
+		value, err := materializeTestRunnerValue(t, ctx, parameter.Source.Value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		addParameterWithValueNative(t, ctx, parameter.Name, string(encoded))
+	}
+	for _, parameter := range plan.Request.Parameters {
+		if parameter.In == "path" || parameter.Required {
+			applyParameter(parameter)
+		}
+	}
+	if plan.Request.Body != nil {
+		value, err := materializeTestRunnerValue(t, ctx, plan.Request.Body.Value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		body, err := json.Marshal(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		GetRequestParameters(ctx)["body"] = string(body)
+		pathCount, _ := ctx.Get(pathParamCountKey{})
+		ctx.Set(pathParamCountKey{}, pathCount.(int)+1)
+	}
+	for _, parameter := range plan.Request.Parameters {
+		if parameter.In != "path" && !parameter.Required {
+			applyParameter(parameter)
+		}
+	}
+}
+
+type testServerTransport struct {
+	session string
+}
+
+func (transport testServerTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	cloned := request.Clone(request.Context())
+	cloned.Close = true
+	cloned.Header.Set("x-openapi-test-session", transport.session)
+	return http.DefaultTransport.RoundTrip(cloned)
+}

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -287,6 +287,11 @@ func WithClock(ctx context.Context, path string) (context.Context, error) {
 	return context.WithValue(ctx, clockKey, fc), nil
 }
 
+// WithClockAt sets a fixed clock in the context without reading a VCR cassette.
+func WithClockAt(ctx context.Context, now time.Time) context.Context {
+	return context.WithValue(ctx, clockKey, clockwork.NewFakeClockAt(now))
+}
+
 // UniqueEntityName will return a unique string that can be used as a title/description/summary/...
 // of an API entity.
 func UniqueEntityName(ctx context.Context, t *testing.T) *string {


### PR DESCRIPTION
## Summary

- load language-neutral request plans generated by openapi-transformer
- run the SDK Cucumber suite against the generated cassette replay server
- keep the native Cucumber assertions while removing native cassette ownership

## Testing

- generated all 169 feature files and 1,685 request plans
- ran the complete replay suite locally