### PR TITLE
Parse topology_map and funnel widgets

### DIFF
--- a/.generator/src/generator/cli.py
+++ b/.generator/src/generator/cli.py
@@ -58,6 +58,7 @@ def cli(specs, output):
     env.globals["get_container"] = openapi.get_container
     env.globals["get_container_type"] = openapi.get_container_type
     env.globals["get_type_at_path"] = openapi.get_type_at_path
+    env.globals["oneof_array_tiebreaks"] = openapi.oneof_array_tiebreaks
     env.globals["common_package_name"] = COMMON_PACKAGE_NAME
     env.globals["module"] = MODULE
 

--- a/.generator/src/generator/openapi.py
+++ b/.generator/src/generator/openapi.py
@@ -1,3 +1,4 @@
+import collections
 import hashlib
 import json
 import pathlib
@@ -11,6 +12,7 @@ from urllib.parse import urlparse
 from yaml import CSafeLoader
 
 from . import formatter
+from . import utils
 
 
 def load(filename):
@@ -125,6 +127,74 @@ def responses_by_types(operation):
         else:
             result[response_type] = [response, [response_code]]
     return result.items()
+
+
+OneOfArrayTiebreak = collections.namedtuple("OneOfArrayTiebreak", ["variant", "arrays"])
+
+
+def _variant_name(variant):
+    """Return the Go field name a oneOf gives the variant."""
+    return utils.upperfirst(get_name(variant) or type_to_go(variant))
+
+
+def _model_arrays(variant, models):
+    """Return {property name: Go type} for the properties a variant declares as arrays of models."""
+    result = {}
+    for name, spec in variant.get("properties", {}).items():
+        go_type = type_to_go(
+            spec,
+            alternative_name=_variant_name(variant) + formatter.attribute_name(name),
+            render_nullable=True,
+            required=name in variant.get("required", []),
+        )
+        if go_type.startswith("[]") and go_type[2:] in models:
+            result[name] = go_type
+    return result
+
+
+def _confusable(first, second):
+    """Whether one payload can satisfy both variants.
+
+    The generated code ignores additionalProperties, so a property tells two variants apart
+    only when both declare it, one requires it, and their values cannot overlap.
+    """
+    shared = set(first.get("properties", {})) & set(second.get("properties", {}))
+    required = set(first.get("required", [])) | set(second.get("required", []))
+    for name in shared & required:
+        one, other = first["properties"][name], second["properties"][name]
+        enums = set(one.get("enum") or []), set(other.get("enum") or [])
+        if all(enums) and not enums[0] & enums[1]:
+            return False
+        types = one.get("type"), other.get("type")
+        if all(types) and types[0] != types[1]:
+            return False
+    return True
+
+
+def oneof_array_tiebreaks(model, models):
+    """Return the variants a payload can confuse, with the arrays of models that tell them apart.
+
+    A variant reports its own UnparsedObject, never that of the items it holds, so variants that
+    differ only in the item type of an array all match. Report, per variant, the Go names of the
+    arrays that a confusable variant declares with a different item type.
+    """
+    variants = model.get("oneOf", [])
+    arrays = [_model_arrays(variant, models) for variant in variants]
+    tiebreaks = []
+    for index, variant in enumerate(variants):
+        confusable = [
+            other
+            for other, candidate in enumerate(variants)
+            if other != index and _confusable(variant, candidate)
+        ]
+        distinguishing = [
+            formatter.attribute_name(name)
+            for name, go_type in arrays[index].items()
+            if any(arrays[other].get(name, go_type) != go_type for other in confusable)
+        ]
+        if distinguishing:
+            tiebreaks.append(OneOfArrayTiebreak(_variant_name(variant), distinguishing))
+    return tiebreaks
 
 
 def child_models(schema, alternative_name=None, seen=None, parent=None):

--- a/.generator/src/generator/openapi.py
+++ b/.generator/src/generator/openapi.py
@@ -137,8 +137,14 @@ def _variant_name(variant):
     return utils.upperfirst(get_name(variant) or type_to_go(variant))
 
 
-def _model_arrays(variant, models):
-    """Return {property name: Go type} for the properties a variant declares as arrays of models."""
+def _reports_unparsed_items(go_type, models):
+    """Whether the items of the Go array type each have an UnparsedObject field."""
+    item = models.get(go_type[2:])
+    return item is not None and "enum" not in item
+
+
+def _arrays(variant):
+    """Return {property name: Go type} for the properties a variant declares as arrays."""
     result = {}
     for name, spec in variant.get("properties", {}).items():
         go_type = type_to_go(
@@ -147,7 +153,7 @@ def _model_arrays(variant, models):
             render_nullable=True,
             required=name in variant.get("required", []),
         )
-        if go_type.startswith("[]") and go_type[2:] in models:
+        if go_type.startswith("[]"):
             result[name] = go_type
     return result
 
@@ -179,7 +185,7 @@ def oneof_array_tiebreaks(model, models):
     arrays that a confusable variant declares with a different item type.
     """
     variants = model.get("oneOf", [])
-    arrays = [_model_arrays(variant, models) for variant in variants]
+    arrays = [_arrays(variant) for variant in variants]
     tiebreaks = []
     for index, variant in enumerate(variants):
         confusable = [
@@ -190,7 +196,8 @@ def oneof_array_tiebreaks(model, models):
         distinguishing = [
             formatter.attribute_name(name)
             for name, go_type in arrays[index].items()
-            if any(arrays[other].get(name, go_type) != go_type for other in confusable)
+            if _reports_unparsed_items(go_type, models)
+            and any(arrays[other].get(name, go_type) != go_type for other in confusable)
         ]
         if distinguishing:
             tiebreaks.append(OneOfArrayTiebreak(_variant_name(variant), distinguishing))

--- a/.generator/src/generator/templates/model_oneof.j2
+++ b/.generator/src/generator/templates/model_oneof.j2
@@ -69,6 +69,32 @@ func (obj *{{ name }}) UnmarshalJSON(data []byte) error {
 		obj.{{ attributeName }} = nil
 	}
 {% endfor %}
+	{#- Break a tie between variants that differ only in the item type of an array by rejecting a
+	    variant whose array of models failed to parse entirely, since the discriminating value hides
+	    in the items. An empty or partially parsed array is accepted. #}
+	{%- set tiebreaks = oneof_array_tiebreaks(model, models) %}
+	{%- if tiebreaks %}
+	if match > 1 {
+		// more than one variant matched, so tell them apart by the items of the arrays they hold
+	{%- for tiebreak in tiebreaks %}
+		if obj.{{ tiebreak.variant }} != nil {
+		{%- for array in tiebreak.arrays %}
+			all{{ array }}Unparsed := len(obj.{{ tiebreak.variant }}.{{ array }}) > 0
+			for _, item := range obj.{{ tiebreak.variant }}.{{ array }} {
+				if item.UnparsedObject == nil {
+					all{{ array }}Unparsed = false
+					break
+				}
+			}
+		{%- endfor %}
+			if {% for array in tiebreak.arrays %}{{ " || " if not loop.first }}all{{ array }}Unparsed{% endfor %} {
+				obj.{{ tiebreak.variant }} = nil
+				match--
+			}
+		}
+	{%- endfor %}
+	}
+	{% endif %}
 	if match != 1 { // more than 1 match
 		// reset to nil
 		{%- for oneOf in model.oneOf %}

--- a/api/datadogV1/model_topology_map_widget_definition.go
+++ b/api/datadogV1/model_topology_map_widget_definition.go
@@ -65,6 +65,36 @@ func (obj *TopologyMapWidgetDefinition) UnmarshalJSON(data []byte) error {
 		obj.TopologyMapWidgetDefinitionServiceMap = nil
 	}
 
+	if match > 1 {
+		// more than one variant matched, so tell them apart by the items of the arrays they hold
+		if obj.TopologyMapWidgetDefinitionDataStreams != nil {
+			allRequestsUnparsed := len(obj.TopologyMapWidgetDefinitionDataStreams.Requests) > 0
+			for _, item := range obj.TopologyMapWidgetDefinitionDataStreams.Requests {
+				if item.UnparsedObject == nil {
+					allRequestsUnparsed = false
+					break
+				}
+			}
+			if allRequestsUnparsed {
+				obj.TopologyMapWidgetDefinitionDataStreams = nil
+				match--
+			}
+		}
+		if obj.TopologyMapWidgetDefinitionServiceMap != nil {
+			allRequestsUnparsed := len(obj.TopologyMapWidgetDefinitionServiceMap.Requests) > 0
+			for _, item := range obj.TopologyMapWidgetDefinitionServiceMap.Requests {
+				if item.UnparsedObject == nil {
+					allRequestsUnparsed = false
+					break
+				}
+			}
+			if allRequestsUnparsed {
+				obj.TopologyMapWidgetDefinitionServiceMap = nil
+				match--
+			}
+		}
+	}
+
 	if match != 1 { // more than 1 match
 		// reset to nil
 		obj.TopologyMapWidgetDefinitionDataStreams = nil

--- a/api/datadogV1/model_widget_definition.go
+++ b/api/datadogV1/model_widget_definition.go
@@ -962,6 +962,36 @@ func (obj *WidgetDefinition) UnmarshalJSON(data []byte) error {
 		obj.WildcardWidgetDefinition = nil
 	}
 
+	if match > 1 {
+		// more than one variant matched, so tell them apart by the items of the arrays they hold
+		if obj.FunnelWidgetDefinition != nil {
+			allRequestsUnparsed := len(obj.FunnelWidgetDefinition.Requests) > 0
+			for _, item := range obj.FunnelWidgetDefinition.Requests {
+				if item.UnparsedObject == nil {
+					allRequestsUnparsed = false
+					break
+				}
+			}
+			if allRequestsUnparsed {
+				obj.FunnelWidgetDefinition = nil
+				match--
+			}
+		}
+		if obj.ProductAnalyticsFunnelWidgetDefinition != nil {
+			allRequestsUnparsed := len(obj.ProductAnalyticsFunnelWidgetDefinition.Requests) > 0
+			for _, item := range obj.ProductAnalyticsFunnelWidgetDefinition.Requests {
+				if item.UnparsedObject == nil {
+					allRequestsUnparsed = false
+					break
+				}
+			}
+			if allRequestsUnparsed {
+				obj.ProductAnalyticsFunnelWidgetDefinition = nil
+				match--
+			}
+		}
+	}
+
 	if match != 1 { // more than 1 match
 		// reset to nil
 		obj.AlertGraphWidgetDefinition = nil

--- a/api/datadogV2/model_security_monitoring_rule_convert_payload.go
+++ b/api/datadogV2/model_security_monitoring_rule_convert_payload.go
@@ -65,6 +65,36 @@ func (obj *SecurityMonitoringRuleConvertPayload) UnmarshalJSON(data []byte) erro
 		obj.SecurityMonitoringSignalRulePayload = nil
 	}
 
+	if match > 1 {
+		// more than one variant matched, so tell them apart by the items of the arrays they hold
+		if obj.SecurityMonitoringStandardRulePayload != nil {
+			allQueriesUnparsed := len(obj.SecurityMonitoringStandardRulePayload.Queries) > 0
+			for _, item := range obj.SecurityMonitoringStandardRulePayload.Queries {
+				if item.UnparsedObject == nil {
+					allQueriesUnparsed = false
+					break
+				}
+			}
+			if allQueriesUnparsed {
+				obj.SecurityMonitoringStandardRulePayload = nil
+				match--
+			}
+		}
+		if obj.SecurityMonitoringSignalRulePayload != nil {
+			allQueriesUnparsed := len(obj.SecurityMonitoringSignalRulePayload.Queries) > 0
+			for _, item := range obj.SecurityMonitoringSignalRulePayload.Queries {
+				if item.UnparsedObject == nil {
+					allQueriesUnparsed = false
+					break
+				}
+			}
+			if allQueriesUnparsed {
+				obj.SecurityMonitoringSignalRulePayload = nil
+				match--
+			}
+		}
+	}
+
 	if match != 1 { // more than 1 match
 		// reset to nil
 		obj.SecurityMonitoringStandardRulePayload = nil

--- a/api/datadogV2/model_security_monitoring_rule_create_payload.go
+++ b/api/datadogV2/model_security_monitoring_rule_create_payload.go
@@ -88,6 +88,63 @@ func (obj *SecurityMonitoringRuleCreatePayload) UnmarshalJSON(data []byte) error
 		obj.CloudConfigurationRuleCreatePayload = nil
 	}
 
+	if match > 1 {
+		// more than one variant matched, so tell them apart by the items of the arrays they hold
+		if obj.SecurityMonitoringStandardRuleCreatePayload != nil {
+			allCasesUnparsed := len(obj.SecurityMonitoringStandardRuleCreatePayload.Cases) > 0
+			for _, item := range obj.SecurityMonitoringStandardRuleCreatePayload.Cases {
+				if item.UnparsedObject == nil {
+					allCasesUnparsed = false
+					break
+				}
+			}
+			allQueriesUnparsed := len(obj.SecurityMonitoringStandardRuleCreatePayload.Queries) > 0
+			for _, item := range obj.SecurityMonitoringStandardRuleCreatePayload.Queries {
+				if item.UnparsedObject == nil {
+					allQueriesUnparsed = false
+					break
+				}
+			}
+			if allCasesUnparsed || allQueriesUnparsed {
+				obj.SecurityMonitoringStandardRuleCreatePayload = nil
+				match--
+			}
+		}
+		if obj.SecurityMonitoringSignalRuleCreatePayload != nil {
+			allCasesUnparsed := len(obj.SecurityMonitoringSignalRuleCreatePayload.Cases) > 0
+			for _, item := range obj.SecurityMonitoringSignalRuleCreatePayload.Cases {
+				if item.UnparsedObject == nil {
+					allCasesUnparsed = false
+					break
+				}
+			}
+			allQueriesUnparsed := len(obj.SecurityMonitoringSignalRuleCreatePayload.Queries) > 0
+			for _, item := range obj.SecurityMonitoringSignalRuleCreatePayload.Queries {
+				if item.UnparsedObject == nil {
+					allQueriesUnparsed = false
+					break
+				}
+			}
+			if allCasesUnparsed || allQueriesUnparsed {
+				obj.SecurityMonitoringSignalRuleCreatePayload = nil
+				match--
+			}
+		}
+		if obj.CloudConfigurationRuleCreatePayload != nil {
+			allCasesUnparsed := len(obj.CloudConfigurationRuleCreatePayload.Cases) > 0
+			for _, item := range obj.CloudConfigurationRuleCreatePayload.Cases {
+				if item.UnparsedObject == nil {
+					allCasesUnparsed = false
+					break
+				}
+			}
+			if allCasesUnparsed {
+				obj.CloudConfigurationRuleCreatePayload = nil
+				match--
+			}
+		}
+	}
+
 	if match != 1 { // more than 1 match
 		// reset to nil
 		obj.SecurityMonitoringStandardRuleCreatePayload = nil

--- a/api/datadogV2/model_security_monitoring_rule_response.go
+++ b/api/datadogV2/model_security_monitoring_rule_response.go
@@ -65,6 +65,36 @@ func (obj *SecurityMonitoringRuleResponse) UnmarshalJSON(data []byte) error {
 		obj.SecurityMonitoringSignalRuleResponse = nil
 	}
 
+	if match > 1 {
+		// more than one variant matched, so tell them apart by the items of the arrays they hold
+		if obj.SecurityMonitoringStandardRuleResponse != nil {
+			allQueriesUnparsed := len(obj.SecurityMonitoringStandardRuleResponse.Queries) > 0
+			for _, item := range obj.SecurityMonitoringStandardRuleResponse.Queries {
+				if item.UnparsedObject == nil {
+					allQueriesUnparsed = false
+					break
+				}
+			}
+			if allQueriesUnparsed {
+				obj.SecurityMonitoringStandardRuleResponse = nil
+				match--
+			}
+		}
+		if obj.SecurityMonitoringSignalRuleResponse != nil {
+			allQueriesUnparsed := len(obj.SecurityMonitoringSignalRuleResponse.Queries) > 0
+			for _, item := range obj.SecurityMonitoringSignalRuleResponse.Queries {
+				if item.UnparsedObject == nil {
+					allQueriesUnparsed = false
+					break
+				}
+			}
+			if allQueriesUnparsed {
+				obj.SecurityMonitoringSignalRuleResponse = nil
+				match--
+			}
+		}
+	}
+
 	if match != 1 { // more than 1 match
 		// reset to nil
 		obj.SecurityMonitoringStandardRuleResponse = nil

--- a/api/datadogV2/model_security_monitoring_rule_validate_payload.go
+++ b/api/datadogV2/model_security_monitoring_rule_validate_payload.go
@@ -88,6 +88,63 @@ func (obj *SecurityMonitoringRuleValidatePayload) UnmarshalJSON(data []byte) err
 		obj.CloudConfigurationRulePayload = nil
 	}
 
+	if match > 1 {
+		// more than one variant matched, so tell them apart by the items of the arrays they hold
+		if obj.SecurityMonitoringStandardRulePayload != nil {
+			allCasesUnparsed := len(obj.SecurityMonitoringStandardRulePayload.Cases) > 0
+			for _, item := range obj.SecurityMonitoringStandardRulePayload.Cases {
+				if item.UnparsedObject == nil {
+					allCasesUnparsed = false
+					break
+				}
+			}
+			allQueriesUnparsed := len(obj.SecurityMonitoringStandardRulePayload.Queries) > 0
+			for _, item := range obj.SecurityMonitoringStandardRulePayload.Queries {
+				if item.UnparsedObject == nil {
+					allQueriesUnparsed = false
+					break
+				}
+			}
+			if allCasesUnparsed || allQueriesUnparsed {
+				obj.SecurityMonitoringStandardRulePayload = nil
+				match--
+			}
+		}
+		if obj.SecurityMonitoringSignalRulePayload != nil {
+			allCasesUnparsed := len(obj.SecurityMonitoringSignalRulePayload.Cases) > 0
+			for _, item := range obj.SecurityMonitoringSignalRulePayload.Cases {
+				if item.UnparsedObject == nil {
+					allCasesUnparsed = false
+					break
+				}
+			}
+			allQueriesUnparsed := len(obj.SecurityMonitoringSignalRulePayload.Queries) > 0
+			for _, item := range obj.SecurityMonitoringSignalRulePayload.Queries {
+				if item.UnparsedObject == nil {
+					allQueriesUnparsed = false
+					break
+				}
+			}
+			if allCasesUnparsed || allQueriesUnparsed {
+				obj.SecurityMonitoringSignalRulePayload = nil
+				match--
+			}
+		}
+		if obj.CloudConfigurationRulePayload != nil {
+			allCasesUnparsed := len(obj.CloudConfigurationRulePayload.Cases) > 0
+			for _, item := range obj.CloudConfigurationRulePayload.Cases {
+				if item.UnparsedObject == nil {
+					allCasesUnparsed = false
+					break
+				}
+			}
+			if allCasesUnparsed {
+				obj.CloudConfigurationRulePayload = nil
+				match--
+			}
+		}
+	}
+
 	if match != 1 { // more than 1 match
 		// reset to nil
 		obj.SecurityMonitoringStandardRulePayload = nil

--- a/tests/api/deserialization_test.go
+++ b/tests/api/deserialization_test.go
@@ -351,3 +351,252 @@ func TestDeserializationUnknownNestedOneOf(t *testing.T) {
 	assert.Equal("A non existent destination", resp.Data.Attributes.Destination.Get().UnparsedObject.(map[string]interface{})["type"])
 	assert.True(datadog.ContainsUnparsedObject(resp))
 }
+
+func TestDeserializationOneOfTopologyMapDiscriminatedInsideList(t *testing.T) {
+	ctx, finish := tests.WithTestSpan(context.Background(), t)
+	defer finish()
+	ctx = testV1.WithClient(testV1.WithFakeAuth(ctx))
+	assert := tests.Assert(ctx, t)
+	api := datadogV1.NewDashboardsApi(testV1.Client(ctx))
+
+	responseBody := `
+{
+    "id": "abc-def-ghi",
+    "title": "Topology",
+    "layout_type": "ordered",
+    "widgets": [
+        {
+            "id": 1,
+            "definition": {
+                "type": "topology_map",
+                "title": "Service map",
+                "requests": [
+                    {
+                        "request_type": "topology",
+                        "query": {
+                            "data_source": "service_map",
+                            "filters": ["env:prod"],
+                            "service": "master-db"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}
+`
+	// Mock the dashboards API.
+	URL, err := testV1.Client(ctx).GetConfig().ServerURLWithContext(ctx, "v1.DashboardsApi.GetDashboard")
+	assert.NoError(err)
+
+	gock.New(URL).
+		Get("dashboard/dashboard_id").
+		Reply(299).
+		AddHeader("Content-Type", "application/json").
+		Body(strings.NewReader(responseBody))
+	defer gock.Off()
+
+	resp, httpresp, err := api.GetDashboard(ctx, "dashboard_id")
+	assert.Nil(err)
+	assert.Equal(299, httpresp.StatusCode)
+	// Root object deserializes correctly, and holds the expected widget
+	assert.Nil(resp.UnparsedObject)
+	assert.Len(resp.GetWidgets(), 1)
+	assert.False(datadog.ContainsUnparsedObject(resp))
+
+	// The widget resolves to the service_map variant, not the data_streams one
+	definition := resp.GetWidgets()[0].Definition.TopologyMapWidgetDefinition
+	assert.NotNil(definition)
+	assert.NotNil(definition.TopologyMapWidgetDefinitionServiceMap)
+	assert.Nil(definition.TopologyMapWidgetDefinitionDataStreams)
+
+	// The dashboard round-trips
+	out, err := datadog.Marshal(&resp)
+	assert.NoError(err)
+	assert.JSONEq(responseBody, string(out))
+}
+
+func TestDeserializationOneOfFunnelDiscriminatedInsideList(t *testing.T) {
+	ctx, finish := tests.WithTestSpan(context.Background(), t)
+	defer finish()
+	ctx = testV1.WithClient(testV1.WithFakeAuth(ctx))
+	assert := tests.Assert(ctx, t)
+	api := datadogV1.NewDashboardsApi(testV1.Client(ctx))
+
+	responseBody := `
+{
+    "id": "abc-def-ghi",
+    "title": "Funnels",
+    "layout_type": "ordered",
+    "widgets": [
+        {
+            "id": 1,
+            "definition": {
+                "type": "funnel",
+                "title": "Checkout funnel",
+                "requests": [
+                    {
+                        "request_type": "funnel",
+                        "query": {
+                            "data_source": "rum",
+                            "query_string": "@browser.name:Chrome",
+                            "steps": [
+                                {
+                                    "facet": "@view.name",
+                                    "value": "/home"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}
+`
+	// Mock the dashboards API.
+	URL, err := testV1.Client(ctx).GetConfig().ServerURLWithContext(ctx, "v1.DashboardsApi.GetDashboard")
+	assert.NoError(err)
+
+	gock.New(URL).
+		Get("dashboard/dashboard_id").
+		Reply(299).
+		AddHeader("Content-Type", "application/json").
+		Body(strings.NewReader(responseBody))
+	defer gock.Off()
+
+	resp, httpresp, err := api.GetDashboard(ctx, "dashboard_id")
+	assert.Nil(err)
+	assert.Equal(299, httpresp.StatusCode)
+	// Root object deserializes correctly, and holds the expected widget
+	assert.Nil(resp.UnparsedObject)
+	assert.Len(resp.GetWidgets(), 1)
+	assert.False(datadog.ContainsUnparsedObject(resp))
+
+	// The widget resolves to the funnel variant, not the product analytics one
+	definition := resp.GetWidgets()[0].Definition
+	assert.NotNil(definition.FunnelWidgetDefinition)
+	assert.Nil(definition.ProductAnalyticsFunnelWidgetDefinition)
+
+	// The dashboard round-trips
+	out, err := datadog.Marshal(&resp)
+	assert.NoError(err)
+	assert.JSONEq(responseBody, string(out))
+}
+
+func TestDeserializationOneOfWithPartiallyUnparsedList(t *testing.T) {
+	ctx, finish := tests.WithTestSpan(context.Background(), t)
+	defer finish()
+	ctx = testV2.WithClient(testV2.WithFakeAuth(ctx))
+	assert := tests.Assert(ctx, t)
+	api := datadogV2.NewSecurityMonitoringApi(testV2.Client(ctx))
+
+	responseBody := `
+{
+    "id": "abc-def-ghi",
+    "name": "Correlated logins",
+    "message": "Two rules fired for the same user",
+    "isEnabled": true,
+    "queries": [
+        {
+            "name": "a",
+            "ruleId": "org-ru1-e1d",
+            "dataSource": "A non existent data source"
+        },
+        {
+            "name": "b",
+            "ruleId": "org-ru1-e1e",
+            "aggregation": "A non existent aggregation"
+        }
+    ]
+}
+`
+	// Mock the security monitoring API.
+	URL, err := testV2.Client(ctx).GetConfig().ServerURLWithContext(ctx, "v2.SecurityMonitoringApi.GetSecurityMonitoringRule")
+	assert.NoError(err)
+
+	gock.New(URL).
+		Get("security_monitoring/rules/rule_id").
+		Reply(299).
+		AddHeader("Content-Type", "application/json").
+		Body(strings.NewReader(responseBody))
+	defer gock.Off()
+
+	resp, httpresp, err := api.GetSecurityMonitoringRule(ctx, "rule_id")
+	assert.Nil(err)
+	assert.Equal(299, httpresp.StatusCode)
+	assert.True(datadog.ContainsUnparsedObject(resp))
+
+	// The standard rule variant reads dataSource, so both of its queries are unparsed and it is
+	// rejected. The signal rule variant keeps the first query, so exactly one variant matches.
+	assert.Nil(resp.UnparsedObject)
+	assert.Nil(resp.SecurityMonitoringStandardRuleResponse)
+	signal := resp.SecurityMonitoringSignalRuleResponse
+	assert.NotNil(signal)
+	assert.Nil(signal.UnparsedObject)
+	assert.Len(signal.GetQueries(), 2)
+	assert.Nil(signal.GetQueries()[0].UnparsedObject)
+	assert.NotNil(signal.GetQueries()[1].UnparsedObject)
+
+	// The rule round-trips
+	out, err := datadog.Marshal(&resp)
+	assert.NoError(err)
+	assert.JSONEq(responseBody, string(out))
+}
+
+func TestDeserializationOneOfWithUnrelatedAmbiguity(t *testing.T) {
+	ctx, finish := tests.WithTestSpan(context.Background(), t)
+	defer finish()
+	ctx = testV2.WithClient(testV2.WithFakeAuth(ctx))
+	assert := tests.Assert(ctx, t)
+	api := datadogV2.NewDowntimesApi(testV2.Client(ctx))
+
+	responseBody := `
+{
+    "data": {
+        "type": "downtime",
+        "id": "00000000-0000-1234-0000-000000000000",
+        "attributes": {
+            "message": "Ambiguous schedule",
+            "schedule": {
+                "start": "2020-01-02T03:04:00+00:00",
+                "timezone": "UTC",
+                "recurrences": [
+                    {
+                        "duration": "1h",
+                        "rrule": "FREQ=DAILY;INTERVAL=1"
+                    }
+                ]
+            }
+        }
+    }
+}
+`
+	// Mock the downtimes API.
+	URL, err := testV2.Client(ctx).GetConfig().ServerURLWithContext(ctx, "v2.DowntimesApi.GetDowntime")
+	assert.NoError(err)
+
+	gock.New(URL).
+		Get("downtime/downtime_id").
+		Reply(299).
+		AddHeader("Content-Type", "application/json").
+		Body(strings.NewReader(responseBody))
+	defer gock.Off()
+
+	resp, httpresp, err := api.GetDowntime(ctx, "downtime_id")
+	assert.Nil(err)
+	assert.Equal(299, httpresp.StatusCode)
+
+	// Both variants parse, so nothing tells them apart: the schedule stays unparsed instead of
+	// silently picking a variant.
+	schedule := resp.Data.Attributes.Schedule
+	assert.NotNil(schedule.UnparsedObject)
+	assert.Nil(schedule.DowntimeScheduleRecurrencesResponse)
+	assert.Nil(schedule.DowntimeScheduleOneTimeResponse)
+	assert.True(datadog.ContainsUnparsedObject(resp))
+
+	// The downtime round-trips
+	out, err := datadog.Marshal(&resp)
+	assert.NoError(err)
+	assert.JSONEq(responseBody, string(out))
+}


### PR DESCRIPTION
### What does this PR do?

`TopologyMapWidgetDefinition` is a oneOf with no discriminator. (See https://github.com/DataDog/datadog-api-spec/pull/5974) Its variants have identical property sets; the only distinguishing value is `requests[].query.data_source`, a single-value enum two levels inside an array item.

Currently, array "hides" whether its children are `UnparsedObject`; that means both variants of `TopologyMapWidgetDefinition` see their `requests` as "valid" (even though only one is actually valid). That means both variants of `TopologyMapWidgetDefinition` match => so the `TopologyMapWidgetDefinition` does _not_ match (since we can't pick a single variant).

This was a latent bug: we've been accidentally setting `UnparsedObject` in a few places -- e.g., Funnel widgets.

_Why_ does an array "hide" whether its children are `UnparsedObject`? It's a future-proofing heuristic. If a customer downloads `datadog-api-client-go` _today_, then it can handle all today's `dashboard.widgets`. But in the future, if we add a new widget type on backend and the customer doesn't update `datadog-api-client-go`, we don't want the _dashboard_ to be `UnparsedObject`.

This PR tweaks the heuristic by adding a "tiebreaker" mode. If array-of-oneof matches more than one variant, un-match variants that look way-off.

### Additional Notes

https://app.datadoghq.com/incidents/58996

Also affects `funnel` widget. (See added tests.)

### Review checklist

Please check relevant items below:

- [x] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
