### PR TITLE
[AGV-1599] Add is_iac support to send X-Datadog-Managed-By header

### DIFF
--- a/.generator/src/generator/templates/configuration.j2
+++ b/.generator/src/generator/templates/configuration.j2
@@ -221,6 +221,21 @@ func (c *Configuration) AddDefaultHeader(key string, value string) {
 	c.DefaultHeader[key] = value
 }
 
+// managedByIaCHeader is the HTTP header used to signal that requests originate
+// from infrastructure-as-code tooling.
+const managedByIaCHeader = "X-Datadog-Managed-By"
+
+// SetIsIaC marks whether requests made through this client originate from
+// infrastructure-as-code tooling. When enabled, every request sent using this
+// configuration includes the `X-Datadog-Managed-By: iac` header.
+func (c *Configuration) SetIsIaC(enabled bool) {
+	if enabled {
+		c.DefaultHeader[managedByIaCHeader] = "iac"
+	} else {
+		delete(c.DefaultHeader, managedByIaCHeader)
+	}
+}
+
 // URL formats template on a index using given variables.
 func (sc ServerConfigurations) URL(index int, variables map[string]string) (string, error) {
 	if index < 0 || len(sc) <= index {

--- a/api/datadog/configuration.go
+++ b/api/datadog/configuration.go
@@ -1344,6 +1344,21 @@ func (c *Configuration) AddDefaultHeader(key string, value string) {
 	c.DefaultHeader[key] = value
 }
 
+// managedByIaCHeader is the HTTP header used to signal that requests originate
+// from infrastructure-as-code tooling.
+const managedByIaCHeader = "X-Datadog-Managed-By"
+
+// SetIsIaC marks whether requests made through this client originate from
+// infrastructure-as-code tooling. When enabled, every request sent using this
+// configuration includes the `X-Datadog-Managed-By: iac` header.
+func (c *Configuration) SetIsIaC(enabled bool) {
+	if enabled {
+		c.DefaultHeader[managedByIaCHeader] = "iac"
+	} else {
+		delete(c.DefaultHeader, managedByIaCHeader)
+	}
+}
+
 // URL formats template on a index using given variables.
 func (sc ServerConfigurations) URL(index int, variables map[string]string) (string, error) {
 	if index < 0 || len(sc) <= index {

--- a/tests/api/datadogV1/configuration_test.go
+++ b/tests/api/datadogV1/configuration_test.go
@@ -3,6 +3,8 @@ package test
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
@@ -62,4 +64,29 @@ func TestConfigurationServersAccess(t *testing.T) {
 			assert.Error(err, tc.Err)
 		})
 	}
+}
+
+func TestConfigurationSetIsIaC(t *testing.T) {
+	assert := tests.Assert(context.Background(), t)
+
+	configuration := datadog.NewConfiguration()
+	apiClient := datadog.NewAPIClient(configuration)
+
+	buildRequest := func() *http.Request {
+		headerParams := map[string]string{}
+		req, err := apiClient.PrepareRequest(context.Background(), "https://example.com", "GET", nil, headerParams, url.Values{}, url.Values{}, nil)
+		if err != nil {
+			t.Fatalf("Could not prepare request: %v", err)
+		}
+		return req
+	}
+
+	// Disabled by default: no callers should see this header unless they opt in.
+	assert.Equal(buildRequest().Header.Get("X-Datadog-Managed-By"), "")
+
+	configuration.SetIsIaC(true)
+	assert.Equal(buildRequest().Header.Get("X-Datadog-Managed-By"), "iac")
+
+	configuration.SetIsIaC(false)
+	assert.Equal(buildRequest().Header.Get("X-Datadog-Managed-By"), "")
 }


### PR DESCRIPTION
## Summary
- Adds `Configuration.SetIsIaC(bool)`, which when enabled sends the `X-Datadog-Managed-By: iac` header on all requests.
- Lets Datadog distinguish infrastructure-as-code API traffic from other client usage.
- Configured at client-creation time via `Configuration`; existing constructors are unaffected.

## Test plan
- [x] `TestConfigurationSetIsIaC` added: verifies header absent by default, present after `SetIsIaC(true)`, removed after `SetIsIaC(false)`
- [x] Full test suite passes

___All of the API generation is moving to a new repo. This PR may never be merged, but changes are present in [openapi-transformer#389](https://github.com/DataDog/openapi-transformer/pull/389)___

🤖 Generated with [Claude Code](https://claude.com/claude-code)