### PR TITLE
Add configurable retry jitter

### DIFF
--- a/.generator/src/generator/templates/client.j2
+++ b/.generator/src/generator/templates/client.j2
@@ -12,6 +12,7 @@ import (
 	"io"
 	"log"
 	"math"
+	"math/rand"
 	"mime/multipart"
 	"net/http"
 	"net/http/httputil"
@@ -236,7 +237,7 @@ func (c *APIClient) shouldRetryRequest(response *http.Response, retryCount int) 
 	if v := response.Header.Get(rateLimitResetHeader); response.StatusCode == 429 && v != "" {
 		vInt, err := strconv.ParseInt(v, 10, 64)
 		if err == nil {
-			retryDuration := time.Duration(vInt) * time.Second
+			retryDuration := time.Duration(vInt)*time.Second + c.retryJitter()
 			return &retryDuration, true
 		}
 	}
@@ -250,10 +251,18 @@ func (c *APIClient) shouldRetryRequest(response *http.Response, retryCount int) 
 		if c.Cfg.HTTPClient.Timeout > 0 {
 			retryVal = math.Min(float64(c.Cfg.HTTPClient.Timeout/time.Second), retryVal)
 		}
-		retryDuration := time.Duration(retryVal) * time.Second
+		retryDuration := time.Duration(retryVal)*time.Second + c.retryJitter()
 		return &retryDuration, true
 	}
 	return nil, false
+}
+
+func (c *APIClient) retryJitter() time.Duration {
+	max := c.Cfg.RetryConfiguration.RetryJitter
+	if max <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int63n(int64(max)))
 }
 
 // GetConfig allows modification of underlying config for alternate implementations and testing.

--- a/.generator/src/generator/templates/configuration.j2
+++ b/.generator/src/generator/templates/configuration.j2
@@ -140,6 +140,7 @@ type RetryConfiguration struct {
 	BackOffBase       float64
 	HTTPRetryTimeout  time.Duration
 	MaxRetries        int
+	RetryJitter       time.Duration
 }
 
 {%- macro server_configuration(server) -%}

--- a/api/datadog/client.go
+++ b/api/datadog/client.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"log"
 	"math"
+	"math/rand"
 	"mime/multipart"
 	"net/http"
 	"net/http/httputil"
@@ -237,7 +238,7 @@ func (c *APIClient) shouldRetryRequest(response *http.Response, retryCount int) 
 	if v := response.Header.Get(rateLimitResetHeader); response.StatusCode == 429 && v != "" {
 		vInt, err := strconv.ParseInt(v, 10, 64)
 		if err == nil {
-			retryDuration := time.Duration(vInt) * time.Second
+			retryDuration := time.Duration(vInt)*time.Second + c.retryJitter()
 			return &retryDuration, true
 		}
 	}
@@ -251,10 +252,18 @@ func (c *APIClient) shouldRetryRequest(response *http.Response, retryCount int) 
 		if c.Cfg.HTTPClient.Timeout > 0 {
 			retryVal = math.Min(float64(c.Cfg.HTTPClient.Timeout/time.Second), retryVal)
 		}
-		retryDuration := time.Duration(retryVal) * time.Second
+		retryDuration := time.Duration(retryVal)*time.Second + c.retryJitter()
 		return &retryDuration, true
 	}
 	return nil, false
+}
+
+func (c *APIClient) retryJitter() time.Duration {
+	max := c.Cfg.RetryConfiguration.RetryJitter
+	if max <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int63n(int64(max)))
 }
 
 // GetConfig allows modification of underlying config for alternate implementations and testing.

--- a/api/datadog/client_retry_test.go
+++ b/api/datadog/client_retry_test.go
@@ -1,0 +1,53 @@
+package datadog
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestRetryJitter(t *testing.T) {
+	tests := []struct {
+		name     string
+		response *http.Response
+		minimum  time.Duration
+	}{
+		{
+			name:     "server error backoff",
+			response: &http.Response{StatusCode: http.StatusInternalServerError, Header: http.Header{}},
+			minimum:  2 * time.Second,
+		},
+		{
+			name: "rate limit reset",
+			response: &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     http.Header{rateLimitResetHeader: []string{"1"}},
+			},
+			minimum: time.Second,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := NewConfiguration()
+			cfg.RetryConfiguration.EnableRetry = true
+			cfg.RetryConfiguration.RetryJitter = time.Second
+			client := NewAPIClient(cfg)
+
+			var observedJitter bool
+			for i := 0; i < 10; i++ {
+				delay, retry := client.shouldRetryRequest(tc.response, 0)
+				if !retry {
+					t.Fatal("expected request to be retried")
+				}
+				if *delay < tc.minimum || *delay >= tc.minimum+time.Second {
+					t.Fatalf("retry delay %s outside [%s, %s)", *delay, tc.minimum, tc.minimum+time.Second)
+				}
+				observedJitter = observedJitter || *delay > tc.minimum
+			}
+			if !observedJitter {
+				t.Fatal("expected a jittered retry delay")
+			}
+		})
+	}
+}

--- a/api/datadog/configuration.go
+++ b/api/datadog/configuration.go
@@ -136,6 +136,7 @@ type RetryConfiguration struct {
 	BackOffBase       float64
 	HTTPRetryTimeout  time.Duration
 	MaxRetries        int
+	RetryJitter       time.Duration
 }
 
 // NewConfiguration returns a new Configuration object.


### PR DESCRIPTION
### What does this PR do?

Adds an optional `RetryJitter` duration to the API client retry configuration. When set, each 429 or 5xx retry delay receives an additive random delay in `[0, RetryJitter)`.

The zero value keeps the existing deterministic retry behavior unchanged. Applying jitter to rate-limit reset retries as well as exponential backoff prevents clients with identical settings from retrying in lockstep.

### Additional Notes

This is the prerequisite for exposing retry jitter in the Terraform provider.

Tested with:
- `go test ./api/datadog`
- `go test ./api/datadog -run '^TestRetryJitter$' -count=20`
- `cd tests && go test ./api`
- a local `httptest` server returning HTTP 500; observed retry gaps of 2.469s and 2.126s with a 2s backoff and 500ms jitter

### Review checklist

- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.
