### PR TITLE
Make configured retry backoff authoritative

### DIFF
--- a/.generator/src/generator/templates/client.j2
+++ b/.generator/src/generator/templates/client.j2
@@ -242,25 +242,31 @@ func (c *APIClient) shouldRetryRequest(response *http.Response, retryCount int) 
 	if !enableRetry || retryCount >= maxRetries {
 		return nil, false
 	}
-	isRetryableStatusCode := response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= http.StatusInternalServerError
-	if !isRetryableStatusCode {
+	isRateLimited := response.StatusCode == http.StatusTooManyRequests
+	isServerError := response.StatusCode >= http.StatusInternalServerError
+	if !isRateLimited && !isServerError {
 		return nil, false
 	}
 
 	retryVal := c.Cfg.RetryConfiguration.BackOffBase * math.Pow(c.Cfg.RetryConfiguration.BackOffMultiplier, float64(retryCount))
 	retryDuration := time.Duration(retryVal) * time.Second
 
-	if response.StatusCode == http.StatusTooManyRequests {
-		if reset, err := strconv.ParseInt(response.Header.Get(rateLimitResetHeader), 10, 64); err == nil && reset >= 0 && reset <= int64((1<<63-1)/time.Second) {
-			resetDuration := time.Duration(reset) * time.Second
-			if resetDuration > retryDuration {
-				retryDuration = resetDuration
-			}
-		}
+	if isRateLimited {
+		retryDuration = max(retryDuration, parseRateLimitReset(response.Header.Get(rateLimitResetHeader)))
 	}
 
 	retryDuration += c.retryJitter()
 	return &retryDuration, true
+}
+
+func parseRateLimitReset(value string) time.Duration {
+	const maxResetSeconds = math.MaxInt64 / int64(time.Second)
+
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || seconds < 0 || seconds > maxResetSeconds {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 func (c *APIClient) retryJitter() time.Duration {

--- a/.generator/src/generator/templates/client.j2
+++ b/.generator/src/generator/templates/client.j2
@@ -168,6 +168,9 @@ func (c *APIClient) CallAPI(request *http.Request) (*http.Response, error) {
 	retryCount := 0
 	for {
 		newRequest := copyRequest(request, &rawBody)
+		if retryCount > 0 {
+			newRequest = newRequest.WithContext(ctx)
+		}
 		if c.Cfg.Debug {
 			dump, err := httputil.DumpRequestOut(newRequest, true)
 			if err != nil {
@@ -214,11 +217,17 @@ func (c *APIClient) CallAPI(request *http.Request) (*http.Response, error) {
 		if !shouldRetry {
 			return resp, requestErr
 		}
+		if deadline, ok := ctx.Deadline(); ok && *retryDuration >= time.Until(deadline) {
+			return resp, requestErr
+		}
 
 		select {
 		case <-ctx.Done():
 			return resp, requestErr
 		case <-time.After(*retryDuration):
+			if resp.Body != nil {
+				resp.Body.Close()
+			}
 			retryCount++
 			continue
 		}
@@ -230,31 +239,27 @@ func (c *APIClient) CallAPI(request *http.Request) (*http.Response, error) {
 func (c *APIClient) shouldRetryRequest(response *http.Response, retryCount int) (*time.Duration, bool) {
 	enableRetry := c.Cfg.RetryConfiguration.EnableRetry
 	maxRetries := c.Cfg.RetryConfiguration.MaxRetries
-	if !enableRetry || retryCount == maxRetries {
+	if !enableRetry || retryCount >= maxRetries {
 		return nil, false
 	}
-	var err error
-	if v := response.Header.Get(rateLimitResetHeader); response.StatusCode == 429 && v != "" {
-		vInt, err := strconv.ParseInt(v, 10, 64)
-		if err == nil {
-			retryDuration := time.Duration(vInt)*time.Second + c.retryJitter()
-			return &retryDuration, true
+	if response.StatusCode != 429 && response.StatusCode < 500 {
+		return nil, false
+	}
+
+	retryVal := c.Cfg.RetryConfiguration.BackOffBase * math.Pow(c.Cfg.RetryConfiguration.BackOffMultiplier, float64(retryCount))
+	retryDuration := time.Duration(retryVal) * time.Second
+
+	if response.StatusCode == 429 {
+		if reset, err := strconv.ParseInt(response.Header.Get(rateLimitResetHeader), 10, 64); err == nil && reset >= 0 && reset <= int64((1<<63-1)/time.Second) {
+			resetDuration := time.Duration(reset) * time.Second
+			if resetDuration > retryDuration {
+				retryDuration = resetDuration
+			}
 		}
 	}
 
-	// Calculate retry for 5xx errors or if unable to parse value of rateLimitResetHeader
-	// or if the `rateLimitResetHeader` header is missing or if status code >= 500.
-	if err != nil || response.StatusCode == 429 || response.StatusCode >= 500 {
-		// Calculate the retry val (base * multiplier^retryCount)
-		retryVal := c.Cfg.RetryConfiguration.BackOffBase * math.Pow(c.Cfg.RetryConfiguration.BackOffMultiplier, float64(retryCount))
-		// retry duration shouldn't exceed the configured timeout period (skip cap when Timeout==0, which means no timeout)
-		if c.Cfg.HTTPClient.Timeout > 0 {
-			retryVal = math.Min(float64(c.Cfg.HTTPClient.Timeout/time.Second), retryVal)
-		}
-		retryDuration := time.Duration(retryVal)*time.Second + c.retryJitter()
-		return &retryDuration, true
-	}
-	return nil, false
+	retryDuration += c.retryJitter()
+	return &retryDuration, true
 }
 
 func (c *APIClient) retryJitter() time.Duration {

--- a/.generator/src/generator/templates/client.j2
+++ b/.generator/src/generator/templates/client.j2
@@ -244,7 +244,8 @@ func (c *APIClient) shouldRetryRequest(response *http.Response, retryCount int) 
 	}
 	isRateLimited := response.StatusCode == http.StatusTooManyRequests
 	isServerError := response.StatusCode >= http.StatusInternalServerError
-	if !isRateLimited && !isServerError {
+	isRetryableStatusCode := isRateLimited || isServerError
+	if !isRetryableStatusCode {
 		return nil, false
 	}
 

--- a/.generator/src/generator/templates/client.j2
+++ b/.generator/src/generator/templates/client.j2
@@ -168,9 +168,6 @@ func (c *APIClient) CallAPI(request *http.Request) (*http.Response, error) {
 	retryCount := 0
 	for {
 		newRequest := copyRequest(request, &rawBody)
-		if retryCount > 0 {
-			newRequest = newRequest.WithContext(ctx)
-		}
 		if c.Cfg.Debug {
 			dump, err := httputil.DumpRequestOut(newRequest, true)
 			if err != nil {

--- a/.generator/src/generator/templates/client.j2
+++ b/.generator/src/generator/templates/client.j2
@@ -242,14 +242,15 @@ func (c *APIClient) shouldRetryRequest(response *http.Response, retryCount int) 
 	if !enableRetry || retryCount >= maxRetries {
 		return nil, false
 	}
-	if response.StatusCode != 429 && response.StatusCode < 500 {
+	isRetryableStatusCode := response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= http.StatusInternalServerError
+	if !isRetryableStatusCode {
 		return nil, false
 	}
 
 	retryVal := c.Cfg.RetryConfiguration.BackOffBase * math.Pow(c.Cfg.RetryConfiguration.BackOffMultiplier, float64(retryCount))
 	retryDuration := time.Duration(retryVal) * time.Second
 
-	if response.StatusCode == 429 {
+	if response.StatusCode == http.StatusTooManyRequests {
 		if reset, err := strconv.ParseInt(response.Header.Get(rateLimitResetHeader), 10, 64); err == nil && reset >= 0 && reset <= int64((1<<63-1)/time.Second) {
 			resetDuration := time.Duration(reset) * time.Second
 			if resetDuration > retryDuration {

--- a/api/datadog/client.go
+++ b/api/datadog/client.go
@@ -169,6 +169,9 @@ func (c *APIClient) CallAPI(request *http.Request) (*http.Response, error) {
 	retryCount := 0
 	for {
 		newRequest := copyRequest(request, &rawBody)
+		if retryCount > 0 {
+			newRequest = newRequest.WithContext(ctx)
+		}
 		if c.Cfg.Debug {
 			dump, err := httputil.DumpRequestOut(newRequest, true)
 			if err != nil {
@@ -215,11 +218,17 @@ func (c *APIClient) CallAPI(request *http.Request) (*http.Response, error) {
 		if !shouldRetry {
 			return resp, requestErr
 		}
+		if deadline, ok := ctx.Deadline(); ok && *retryDuration >= time.Until(deadline) {
+			return resp, requestErr
+		}
 
 		select {
 		case <-ctx.Done():
 			return resp, requestErr
 		case <-time.After(*retryDuration):
+			if resp.Body != nil {
+				resp.Body.Close()
+			}
 			retryCount++
 			continue
 		}
@@ -231,31 +240,27 @@ func (c *APIClient) CallAPI(request *http.Request) (*http.Response, error) {
 func (c *APIClient) shouldRetryRequest(response *http.Response, retryCount int) (*time.Duration, bool) {
 	enableRetry := c.Cfg.RetryConfiguration.EnableRetry
 	maxRetries := c.Cfg.RetryConfiguration.MaxRetries
-	if !enableRetry || retryCount == maxRetries {
+	if !enableRetry || retryCount >= maxRetries {
 		return nil, false
 	}
-	var err error
-	if v := response.Header.Get(rateLimitResetHeader); response.StatusCode == 429 && v != "" {
-		vInt, err := strconv.ParseInt(v, 10, 64)
-		if err == nil {
-			retryDuration := time.Duration(vInt)*time.Second + c.retryJitter()
-			return &retryDuration, true
+	if response.StatusCode != 429 && response.StatusCode < 500 {
+		return nil, false
+	}
+
+	retryVal := c.Cfg.RetryConfiguration.BackOffBase * math.Pow(c.Cfg.RetryConfiguration.BackOffMultiplier, float64(retryCount))
+	retryDuration := time.Duration(retryVal) * time.Second
+
+	if response.StatusCode == 429 {
+		if reset, err := strconv.ParseInt(response.Header.Get(rateLimitResetHeader), 10, 64); err == nil && reset >= 0 && reset <= int64((1<<63-1)/time.Second) {
+			resetDuration := time.Duration(reset) * time.Second
+			if resetDuration > retryDuration {
+				retryDuration = resetDuration
+			}
 		}
 	}
 
-	// Calculate retry for 5xx errors or if unable to parse value of rateLimitResetHeader
-	// or if the `rateLimitResetHeader` header is missing or if status code >= 500.
-	if err != nil || response.StatusCode == 429 || response.StatusCode >= 500 {
-		// Calculate the retry val (base * multiplier^retryCount)
-		retryVal := c.Cfg.RetryConfiguration.BackOffBase * math.Pow(c.Cfg.RetryConfiguration.BackOffMultiplier, float64(retryCount))
-		// retry duration shouldn't exceed the configured timeout period (skip cap when Timeout==0, which means no timeout)
-		if c.Cfg.HTTPClient.Timeout > 0 {
-			retryVal = math.Min(float64(c.Cfg.HTTPClient.Timeout/time.Second), retryVal)
-		}
-		retryDuration := time.Duration(retryVal)*time.Second + c.retryJitter()
-		return &retryDuration, true
-	}
-	return nil, false
+	retryDuration += c.retryJitter()
+	return &retryDuration, true
 }
 
 func (c *APIClient) retryJitter() time.Duration {

--- a/api/datadog/client.go
+++ b/api/datadog/client.go
@@ -245,7 +245,8 @@ func (c *APIClient) shouldRetryRequest(response *http.Response, retryCount int) 
 	}
 	isRateLimited := response.StatusCode == http.StatusTooManyRequests
 	isServerError := response.StatusCode >= http.StatusInternalServerError
-	if !isRateLimited && !isServerError {
+	isRetryableStatusCode := isRateLimited || isServerError
+	if !isRetryableStatusCode {
 		return nil, false
 	}
 

--- a/api/datadog/client.go
+++ b/api/datadog/client.go
@@ -243,25 +243,31 @@ func (c *APIClient) shouldRetryRequest(response *http.Response, retryCount int) 
 	if !enableRetry || retryCount >= maxRetries {
 		return nil, false
 	}
-	isRetryableStatusCode := response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= http.StatusInternalServerError
-	if !isRetryableStatusCode {
+	isRateLimited := response.StatusCode == http.StatusTooManyRequests
+	isServerError := response.StatusCode >= http.StatusInternalServerError
+	if !isRateLimited && !isServerError {
 		return nil, false
 	}
 
 	retryVal := c.Cfg.RetryConfiguration.BackOffBase * math.Pow(c.Cfg.RetryConfiguration.BackOffMultiplier, float64(retryCount))
 	retryDuration := time.Duration(retryVal) * time.Second
 
-	if response.StatusCode == http.StatusTooManyRequests {
-		if reset, err := strconv.ParseInt(response.Header.Get(rateLimitResetHeader), 10, 64); err == nil && reset >= 0 && reset <= int64((1<<63-1)/time.Second) {
-			resetDuration := time.Duration(reset) * time.Second
-			if resetDuration > retryDuration {
-				retryDuration = resetDuration
-			}
-		}
+	if isRateLimited {
+		retryDuration = max(retryDuration, parseRateLimitReset(response.Header.Get(rateLimitResetHeader)))
 	}
 
 	retryDuration += c.retryJitter()
 	return &retryDuration, true
+}
+
+func parseRateLimitReset(value string) time.Duration {
+	const maxResetSeconds = math.MaxInt64 / int64(time.Second)
+
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || seconds < 0 || seconds > maxResetSeconds {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 func (c *APIClient) retryJitter() time.Duration {

--- a/api/datadog/client.go
+++ b/api/datadog/client.go
@@ -243,14 +243,15 @@ func (c *APIClient) shouldRetryRequest(response *http.Response, retryCount int) 
 	if !enableRetry || retryCount >= maxRetries {
 		return nil, false
 	}
-	if response.StatusCode != 429 && response.StatusCode < 500 {
+	isRetryableStatusCode := response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= http.StatusInternalServerError
+	if !isRetryableStatusCode {
 		return nil, false
 	}
 
 	retryVal := c.Cfg.RetryConfiguration.BackOffBase * math.Pow(c.Cfg.RetryConfiguration.BackOffMultiplier, float64(retryCount))
 	retryDuration := time.Duration(retryVal) * time.Second
 
-	if response.StatusCode == 429 {
+	if response.StatusCode == http.StatusTooManyRequests {
 		if reset, err := strconv.ParseInt(response.Header.Get(rateLimitResetHeader), 10, 64); err == nil && reset >= 0 && reset <= int64((1<<63-1)/time.Second) {
 			resetDuration := time.Duration(reset) * time.Second
 			if resetDuration > retryDuration {

--- a/api/datadog/client.go
+++ b/api/datadog/client.go
@@ -169,9 +169,6 @@ func (c *APIClient) CallAPI(request *http.Request) (*http.Response, error) {
 	retryCount := 0
 	for {
 		newRequest := copyRequest(request, &rawBody)
-		if retryCount > 0 {
-			newRequest = newRequest.WithContext(ctx)
-		}
 		if c.Cfg.Debug {
 			dump, err := httputil.DumpRequestOut(newRequest, true)
 			if err != nil {

--- a/api/datadog/client_retry_test.go
+++ b/api/datadog/client_retry_test.go
@@ -37,6 +37,7 @@ func TestRetryBackoffIsMinimum(t *testing.T) {
 		"missing":   "",
 		"malformed": "later",
 		"negative":  "-1",
+		"overflow":  "9223372037",
 	} {
 		t.Run(name+" reset uses backoff", func(t *testing.T) {
 			delay, retry := client.shouldRetryRequest(retryResponse(http.StatusTooManyRequests, reset), 0)

--- a/api/datadog/client_retry_test.go
+++ b/api/datadog/client_retry_test.go
@@ -2,7 +2,6 @@ package datadog
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -163,16 +162,15 @@ func TestRetryMaxAttempts(t *testing.T) {
 	}
 }
 
-func TestRetryDeadlineCancelsInFlightAttempt(t *testing.T) {
+func TestRetryDeadlineAllowsInFlightAttemptToFinish(t *testing.T) {
 	var calls atomic.Int32
-	canceled := make(chan struct{}, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if calls.Add(1) == 1 {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		<-r.Context().Done()
-		canceled <- struct{}{}
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
@@ -186,17 +184,16 @@ func TestRetryDeadlineCancelsInFlightAttempt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = client.CallAPI(request)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("error = %v; want context deadline exceeded", err)
+	response, err := client.CallAPI(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; want %d", response.StatusCode, http.StatusOK)
 	}
 	if calls.Load() != 2 {
 		t.Fatalf("calls = %d; want 2", calls.Load())
-	}
-	select {
-	case <-canceled:
-	case <-time.After(time.Second):
-		t.Fatal("retry request context was not canceled")
 	}
 }
 

--- a/api/datadog/client_retry_test.go
+++ b/api/datadog/client_retry_test.go
@@ -54,6 +54,25 @@ func TestRetryBackoffIsMinimum(t *testing.T) {
 	})
 }
 
+func TestRetryNegativeOrOverflowingResetUsesBackoff(t *testing.T) {
+	cfg := NewConfiguration()
+	cfg.RetryConfiguration.EnableRetry = true
+	cfg.RetryConfiguration.BackOffBase = 5
+	client := NewAPIClient(cfg)
+
+	for name, reset := range map[string]string{
+		"negative": "-1",
+		"overflow": "9223372037",
+	} {
+		t.Run(name, func(t *testing.T) {
+			delay, retry := client.shouldRetryRequest(retryResponse(http.StatusTooManyRequests, reset), 0)
+			if !retry || *delay != 5*time.Second {
+				t.Fatalf("delay, retry = %v, %t; want 5s, true", *delay, retry)
+			}
+		})
+	}
+}
+
 func TestRetryJitter(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/api/datadog/client_retry_test.go
+++ b/api/datadog/client_retry_test.go
@@ -1,10 +1,58 @@
 package datadog
 
 import (
+	"context"
+	"errors"
 	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+func TestRetryBackoffIsMinimum(t *testing.T) {
+	cfg := NewConfiguration()
+	cfg.RetryConfiguration.EnableRetry = true
+	cfg.RetryConfiguration.BackOffBase = 5
+	cfg.RetryConfiguration.BackOffMultiplier = 2
+	cfg.RetryConfiguration.MaxRetries = 5
+	client := NewAPIClient(cfg)
+
+	response := retryResponse(http.StatusTooManyRequests, "1")
+	for retryCount, want := range []time.Duration{5 * time.Second, 10 * time.Second, 20 * time.Second, 40 * time.Second, 80 * time.Second} {
+		delay, retry := client.shouldRetryRequest(response, retryCount)
+		if !retry || *delay != want {
+			t.Fatalf("retry %d: delay, retry = %v, %t; want %v, true", retryCount, *delay, retry, want)
+		}
+	}
+
+	t.Run("longer reset extends delay", func(t *testing.T) {
+		delay, retry := client.shouldRetryRequest(retryResponse(http.StatusTooManyRequests, "30"), 0)
+		if !retry || *delay != 30*time.Second {
+			t.Fatalf("delay, retry = %v, %t; want 30s, true", *delay, retry)
+		}
+	})
+
+	for name, reset := range map[string]string{
+		"missing":   "",
+		"malformed": "later",
+		"negative":  "-1",
+	} {
+		t.Run(name+" reset uses backoff", func(t *testing.T) {
+			delay, retry := client.shouldRetryRequest(retryResponse(http.StatusTooManyRequests, reset), 0)
+			if !retry || *delay != 5*time.Second {
+				t.Fatalf("delay, retry = %v, %t; want 5s, true", *delay, retry)
+			}
+		})
+	}
+
+	t.Run("server error ignores reset", func(t *testing.T) {
+		delay, retry := client.shouldRetryRequest(retryResponse(http.StatusInternalServerError, "30"), 0)
+		if !retry || *delay != 5*time.Second {
+			t.Fatalf("delay, retry = %v, %t; want 5s, true", *delay, retry)
+		}
+	})
+}
 
 func TestRetryJitter(t *testing.T) {
 	tests := []struct {
@@ -14,16 +62,18 @@ func TestRetryJitter(t *testing.T) {
 	}{
 		{
 			name:     "server error backoff",
-			response: &http.Response{StatusCode: http.StatusInternalServerError, Header: http.Header{}},
+			response: retryResponse(http.StatusInternalServerError, ""),
 			minimum:  2 * time.Second,
 		},
 		{
-			name: "rate limit reset",
-			response: &http.Response{
-				StatusCode: http.StatusTooManyRequests,
-				Header:     http.Header{rateLimitResetHeader: []string{"1"}},
-			},
-			minimum: time.Second,
+			name:     "backoff floors rate limit reset",
+			response: retryResponse(http.StatusTooManyRequests, "1"),
+			minimum:  2 * time.Second,
+		},
+		{
+			name:     "rate limit reset extends backoff",
+			response: retryResponse(http.StatusTooManyRequests, "3"),
+			minimum:  3 * time.Second,
 		},
 	}
 
@@ -50,4 +100,109 @@ func TestRetryJitter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRetryDelayOutsideBudgetReturnsImmediately(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set(rateLimitResetHeader, "10")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	cfg := NewConfiguration()
+	cfg.RetryConfiguration.EnableRetry = true
+	cfg.RetryConfiguration.HTTPRetryTimeout = 100 * time.Millisecond
+	client := NewAPIClient(cfg)
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	started := time.Now()
+	response, err := client.CallAPI(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if elapsed := time.Since(started); elapsed >= time.Second {
+		t.Fatalf("request took %s; expected an immediate response", elapsed)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("calls = %d; want 1", calls.Load())
+	}
+}
+
+func TestRetryMaxAttempts(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := NewConfiguration()
+	cfg.RetryConfiguration.EnableRetry = true
+	cfg.RetryConfiguration.MaxRetries = 5
+	client := NewAPIClient(cfg)
+	client.Cfg.RetryConfiguration.BackOffBase = 0 // Keep this attempt-count test instant.
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	response, err := client.CallAPI(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if calls.Load() != 6 {
+		t.Fatalf("calls = %d; want 6", calls.Load())
+	}
+}
+
+func TestRetryDeadlineCancelsInFlightAttempt(t *testing.T) {
+	var calls atomic.Int32
+	canceled := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		<-r.Context().Done()
+		canceled <- struct{}{}
+	}))
+	defer server.Close()
+
+	cfg := NewConfiguration()
+	cfg.RetryConfiguration.EnableRetry = true
+	cfg.RetryConfiguration.HTTPRetryTimeout = 50 * time.Millisecond
+	client := NewAPIClient(cfg)
+	client.Cfg.RetryConfiguration.BackOffBase = 0 // Start the retry immediately.
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.CallAPI(request)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v; want context deadline exceeded", err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("calls = %d; want 2", calls.Load())
+	}
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("retry request context was not canceled")
+	}
+}
+
+func retryResponse(statusCode int, reset string) *http.Response {
+	header := http.Header{}
+	if reset != "" {
+		header.Set(rateLimitResetHeader, reset)
+	}
+	return &http.Response{StatusCode: statusCode, Header: header}
 }


### PR DESCRIPTION
### What does this PR do?

This stacked PR builds on #4517 and makes configured retry backoff authoritative.

#### Notable changes

- Previously, a valid `X-Ratelimit-Reset` value completely replaced configured backoff for a 429 response, even when it requested a shorter delay. This PR uses `max(configured exponential backoff, X-Ratelimit-Reset)`, so the server may extend but never shorten the configured delay.
- Previously, `HTTPClient.Timeout` could shorten configured retry delays even though it is the timeout for an individual HTTP request. It no longer caps backoff.

#### Small changes

- Previously, negative reset values were accepted as negative durations and could cause an immediate retry. Values that fit in `int64` seconds could also overflow when converted to `time.Duration`. Both now fall back to configured backoff.
- Previously, a pre-retry delay that could not fit in the remaining `HTTPRetryTimeout` budget waited until the deadline expired. Because the previous request has already returned, waiting is useless when the delay alone would exhaust the remaining budget; the client now returns that response immediately without starting another attempt.
- Discarded intermediate retry response bodies are now closed before the next attempt.
- The retry limit check is defensively enforced with `retryCount >= MaxRetries`; five retries still allow six total attempts.

#### Preserved behavior

- Missing or malformed reset headers fall back to configured backoff.
- 5xx responses use configured backoff and ignore rate-limit reset headers.
- An HTTP retry that has already started may finish after the retry deadline.
- Standard `Retry-After` handling and transport-error retries remain out of scope.

Jitter is introduced by the stacked PR #4517. This PR applies it after selecting the authoritative delay.

### Additional Notes

Validated with:

- `go test ./api/datadog`
- `go test ./api/datadog -run "^TestRetryJitter$" -count=20`
- `go test ./api/datadog -run "^TestRetryDeadlineAllowsInFlightAttemptToFinish$" -count=10`
- `cd tests && go test ./api`
- generated client/template parity check
- `git diff --check`

### Review checklist

- [x] This PR does not modify cassette-based tests.
- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.