### PR TITLE
Fix generated documentation size limit

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,8 @@ permissions:
   contents: write
 
 on:
+  pull_request:
+    branches: [master]
   push:
     branches:
       - master
@@ -26,8 +28,11 @@ jobs:
           rm -rf tests
           go install github.com/johnstarich/go/gopages@latest
           gopages -source-link "https://github.com/DataDog/datadog-api-client-go/blob/master/{{.Path}}{{if .Line}}#L{{.Line}}{{end}}" -brand-description "Datadog API client for GO" -brand-title "Datadog" -base /datadog-api-client-go
+          find dist -type f -name '*.html' -exec perl -ni -e 'print unless /^[\t ]+$/' {} +
+          ! find dist -type f -size +100M -print -quit | grep .
 
-      - uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
+      - if: github.event_name == 'push'
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist


### PR DESCRIPTION
### What does this PR do?

Strips indentation-only lines from generated HTML before publishing the documentation. This reduces `datadogV2/index.html` below GitHub’s 100 MiB per-file limit.

Adds an explicit size check so future growth fails during documentation generation instead of during the GitHub Pages push.

### Validation

- Reproduced the workflow locally with Go 1.22
- Before: 105,160,826 bytes; size check fails
- After: 99,818,771 bytes; size check passes
- Verified source-code blank lines rendered inside `<pre>` blocks are preserved

### Review checklist

- [ ] This PR includes all newly recorded cassettes for any modified tests.
- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.