### PR TITLE
Add GCP delegated token authentication provider

### DIFF
--- a/.generator/conftest.py
+++ b/.generator/conftest.py
@@ -71,7 +71,8 @@ JINJA_ENV.globals["given_variables"] = given_variables
 
 GO_EXAMPLE_J2 = JINJA_ENV.get_template("example.j2")
 DATADOG_EXAMPLES_J2 = {
-    "aws.go": JINJA_ENV.get_template("example_aws.j2")
+    "aws.go": JINJA_ENV.get_template("example_aws.j2"),
+    "gcp/main.go": JINJA_ENV.get_template("example_gcp.j2")
 }
 
 

--- a/.generator/src/generator/cli.py
+++ b/.generator/src/generator/cli.py
@@ -68,6 +68,7 @@ def cli(specs, output):
 
     extra_files = {
         "aws.go": env.get_template("aws.j2"),
+        "gcp.go": env.get_template("gcp.j2"),
         "client.go": env.get_template("client.j2"),
         "configuration.go": env.get_template("configuration.j2"),
         "delegated_auth.go": env.get_template("delegated_auth.j2"),

--- a/.generator/src/generator/templates/configuration.j2
+++ b/.generator/src/generator/templates/configuration.j2
@@ -45,6 +45,11 @@ var (
 	// ContextAWSVariables takes AWS credentials as authentication for the request.
 	ContextAWSVariables = contextKey("awsVariables")
 
+	// ContextGCPVariables takes GCP credentials (pre-minted identity tokens) as
+	// authentication for the request. Keys use the provider-specific name
+	// constants, e.g. datadog.GCPIdentityTokenName.
+	ContextGCPVariables = contextKey("gcpVariables")
+
 	// ContextHttpSignatureAuth takes HttpSignatureAuth as authentication for the request.
 	ContextHttpSignatureAuth = contextKey("httpsignature")
 
@@ -420,6 +425,16 @@ func NewDefaultContext(ctx context.Context) context.Context {
 		ctx,
 		ContextAWSVariables,
 		awsKeys,
+	)
+
+	gcpKeys := make(map[string]string)
+	if gcpToken, ok := os.LookupEnv(GCPIdentityTokenName); ok {
+		gcpKeys[GCPIdentityTokenName] = gcpToken
+	}
+	ctx = context.WithValue(
+		ctx,
+		ContextGCPVariables,
+		gcpKeys,
 	)
 
 	ctx = context.WithValue(

--- a/.generator/src/generator/templates/example_gcp.j2
+++ b/.generator/src/generator/templates/example_gcp.j2
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func main() {
+	ctx := datadog.NewDefaultContext(context.Background())
+	configuration := datadog.NewConfiguration()
+	configuration.DelegatedTokenConfig = &datadog.DelegatedTokenConfig{
+		OrgUUID: os.Getenv("DD_TEST_ORG_UUID"),
+		ProviderAuth: &datadog.GCPAuth{
+			// Minting via `gcloud` requires impersonating a service account:
+			// user identity tokens cannot set the custom `datadog/<org-uuid>`
+			// audience. Alternatively, pass a pre-minted identity token via
+			// GCPAuth.IdentityToken or the DD_GCP_IDENTITY_TOKEN environment
+			// variable to skip the `gcloud` invocation entirely.
+			ImpersonateServiceAccount: os.Getenv("DD_TEST_GCP_SA_EMAIL"),
+		},
+		Provider: datadog.ProviderGCP,
+	}
+	apiClient := datadog.NewAPIClient(configuration)
+
+	// Make example API call using the DelegatedTokenConfig
+	api := datadogV2.NewTeamsApi(apiClient)
+	resp, r, err := api.ListTeams(ctx, *datadogV2.NewListTeamsOptionalParameters())
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `TeamsApi.ListTeams`: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+
+	responseContent, _ := json.MarshalIndent(resp, "", "  ")
+	fmt.Fprintf(os.Stdout, "Response from `TeamsApi.ListTeams`:\n%s\n", responseContent)
+}
+

--- a/.generator/src/generator/templates/gcp.j2
+++ b/.generator/src/generator/templates/gcp.j2
@@ -1,0 +1,107 @@
+{% include "partial_header.j2" %}
+package {{ common_package_name }}
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const ProviderGCP = "gcp"
+
+// GCPIdentityTokenName is the environment variable carrying a pre-minted GCP
+// identity token, used instead of invoking `gcloud`.
+const GCPIdentityTokenName = "DD_GCP_IDENTITY_TOKEN"
+
+// gcpAudiencePrefix is the audience convention the delegated-token servicer
+// pins every GCP exchange to: the identity token must target
+// `datadog/<org-uuid>` for the org being routed.
+const gcpAudiencePrefix = "datadog/"
+
+// GCPAuth exchanges a Google Cloud identity token for a Datadog delegated token.
+type GCPAuth struct {
+	// ImpersonateServiceAccount is the service-account email used with
+	// `gcloud auth print-identity-token --impersonate-service-account`.
+	// Required for minting: user identity tokens cannot set the custom
+	// `datadog/<org-uuid>` audience the servicer expects.
+	ImpersonateServiceAccount string
+
+	// IdentityToken is an optional pre-minted identity token used verbatim as
+	// the exchange proof, bypassing the `gcloud` invocation. When empty, the
+	// token is sourced from the DD_GCP_IDENTITY_TOKEN environment variable
+	// (or its context override) before falling back to `gcloud`.
+	IdentityToken string
+}
+
+func (g *GCPAuth) Authenticate(ctx context.Context, config *DelegatedTokenConfig) (*DelegatedTokenCredentials, error) {
+	if config == nil || config.OrgUUID == "" {
+		return nil, fmt.Errorf("missing org UUID in config")
+	}
+
+	proof, err := g.GetIdentityToken(ctx, config.OrgUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetDelegatedToken(ctx, config.OrgUUID, proof)
+}
+
+// GetIdentityToken resolves the GCP identity token serving as the exchange
+// proof: the IdentityToken field, then the DD_GCP_IDENTITY_TOKEN environment
+// variable (with its context override), then `gcloud`.
+func (g *GCPAuth) GetIdentityToken(ctx context.Context, orgUUID string) (string, error) {
+	if g.IdentityToken != "" {
+		return g.IdentityToken, nil
+	}
+	if token := gcpTokenFromContextOrEnv(ctx); token != "" {
+		return token, nil
+	}
+	return g.mintIdentityToken(ctx, orgUUID)
+}
+
+// mintIdentityToken invokes `gcloud auth print-identity-token` with the
+// Datadog org audience. Impersonation of a service account is required:
+// `gcloud` rejects `--audiences` for user credentials.
+func (g *GCPAuth) mintIdentityToken(ctx context.Context, orgUUID string) (string, error) {
+	if g.ImpersonateServiceAccount == "" {
+		return "", fmt.Errorf("missing service account to impersonate: set GCPAuth.ImpersonateServiceAccount or provide a pre-minted identity token via GCPAuth.IdentityToken or %s", GCPIdentityTokenName)
+	}
+	if _, err := exec.LookPath("gcloud"); err != nil {
+		return "", fmt.Errorf("`gcloud` not found on PATH (install the Google Cloud CLI and run `gcloud auth login`), or provide a pre-minted identity token")
+	}
+	args := gcloudIdentityTokenArgs(g.ImpersonateServiceAccount, gcpAudiencePrefix+orgUUID)
+	out, err := exec.CommandContext(ctx, "gcloud", args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("gcloud auth print-identity-token: %w (run `gcloud auth login` first)", err)
+	}
+	token := strings.TrimSpace(string(out))
+	if token == "" {
+		return "", fmt.Errorf("gcloud auth print-identity-token returned an empty token")
+	}
+	return token, nil
+}
+
+// gcloudIdentityTokenArgs builds the `gcloud` invocation for minting an
+// identity token with the Datadog org audience and the service-account email
+// in the `email` claim. Factored out for testing.
+func gcloudIdentityTokenArgs(impersonate, audience string) []string {
+	return []string{
+		"auth", "print-identity-token",
+		"--audiences=" + audience,
+		"--impersonate-service-account=" + impersonate,
+		"--include-email",
+	}
+}
+
+// gcpTokenFromContextOrEnv reads a pre-minted identity token from the context
+// override (mirroring ContextAWSVariables), falling back to the environment.
+func gcpTokenFromContextOrEnv(ctx context.Context) string {
+	if keys, ok := ctx.Value(ContextGCPVariables).(map[string]string); ok {
+		if token, ok := keys[GCPIdentityTokenName]; ok {
+			return token
+		}
+	}
+	return os.Getenv(GCPIdentityTokenName)
+}

--- a/.generator/src/generator/templates/gcp.j2
+++ b/.generator/src/generator/templates/gcp.j2
@@ -3,6 +3,7 @@ package {{ common_package_name }}
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -74,6 +75,10 @@ func (g *GCPAuth) mintIdentityToken(ctx context.Context, orgUUID string) (string
 	args := gcloudIdentityTokenArgs(g.ImpersonateServiceAccount, gcpAudiencePrefix+orgUUID)
 	out, err := exec.CommandContext(ctx, "gcloud", args...).Output()
 	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			return "", fmt.Errorf("gcloud auth print-identity-token: %w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
 		return "", fmt.Errorf("gcloud auth print-identity-token: %w (run `gcloud auth login` first)", err)
 	}
 	token := strings.TrimSpace(string(out))
@@ -85,7 +90,7 @@ func (g *GCPAuth) mintIdentityToken(ctx context.Context, orgUUID string) (string
 
 // gcloudIdentityTokenArgs builds the `gcloud` invocation for minting an
 // identity token with the Datadog org audience and the service-account email
-// in the `email` claim. Factored out for testing.
+// in the `email` claim.
 func gcloudIdentityTokenArgs(impersonate, audience string) []string {
 	return []string{
 		"auth", "print-identity-token",

--- a/api/datadog/configuration.go
+++ b/api/datadog/configuration.go
@@ -48,6 +48,11 @@ var (
 	// ContextAWSVariables takes AWS credentials as authentication for the request.
 	ContextAWSVariables = contextKey("awsVariables")
 
+	// ContextGCPVariables takes GCP credentials (pre-minted identity tokens) as
+	// authentication for the request. Keys use the provider-specific name
+	// constants, e.g. datadog.GCPIdentityTokenName.
+	ContextGCPVariables = contextKey("gcpVariables")
+
 	// ContextHttpSignatureAuth takes HttpSignatureAuth as authentication for the request.
 	ContextHttpSignatureAuth = contextKey("httpsignature")
 
@@ -1587,6 +1592,16 @@ func NewDefaultContext(ctx context.Context) context.Context {
 		ctx,
 		ContextAWSVariables,
 		awsKeys,
+	)
+
+	gcpKeys := make(map[string]string)
+	if gcpToken, ok := os.LookupEnv(GCPIdentityTokenName); ok {
+		gcpKeys[GCPIdentityTokenName] = gcpToken
+	}
+	ctx = context.WithValue(
+		ctx,
+		ContextGCPVariables,
+		gcpKeys,
 	)
 
 	ctx = context.WithValue(

--- a/api/datadog/gcp.go
+++ b/api/datadog/gcp.go
@@ -6,6 +6,7 @@ package datadog
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -77,6 +78,10 @@ func (g *GCPAuth) mintIdentityToken(ctx context.Context, orgUUID string) (string
 	args := gcloudIdentityTokenArgs(g.ImpersonateServiceAccount, gcpAudiencePrefix+orgUUID)
 	out, err := exec.CommandContext(ctx, "gcloud", args...).Output()
 	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			return "", fmt.Errorf("gcloud auth print-identity-token: %w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
 		return "", fmt.Errorf("gcloud auth print-identity-token: %w (run `gcloud auth login` first)", err)
 	}
 	token := strings.TrimSpace(string(out))
@@ -88,7 +93,7 @@ func (g *GCPAuth) mintIdentityToken(ctx context.Context, orgUUID string) (string
 
 // gcloudIdentityTokenArgs builds the `gcloud` invocation for minting an
 // identity token with the Datadog org audience and the service-account email
-// in the `email` claim. Factored out for testing.
+// in the `email` claim.
 func gcloudIdentityTokenArgs(impersonate, audience string) []string {
 	return []string{
 		"auth", "print-identity-token",

--- a/api/datadog/gcp.go
+++ b/api/datadog/gcp.go
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const ProviderGCP = "gcp"
+
+// GCPIdentityTokenName is the environment variable carrying a pre-minted GCP
+// identity token, used instead of invoking `gcloud`.
+const GCPIdentityTokenName = "DD_GCP_IDENTITY_TOKEN"
+
+// gcpAudiencePrefix is the audience convention the delegated-token servicer
+// pins every GCP exchange to: the identity token must target
+// `datadog/<org-uuid>` for the org being routed.
+const gcpAudiencePrefix = "datadog/"
+
+// GCPAuth exchanges a Google Cloud identity token for a Datadog delegated token.
+type GCPAuth struct {
+	// ImpersonateServiceAccount is the service-account email used with
+	// `gcloud auth print-identity-token --impersonate-service-account`.
+	// Required for minting: user identity tokens cannot set the custom
+	// `datadog/<org-uuid>` audience the servicer expects.
+	ImpersonateServiceAccount string
+
+	// IdentityToken is an optional pre-minted identity token used verbatim as
+	// the exchange proof, bypassing the `gcloud` invocation. When empty, the
+	// token is sourced from the DD_GCP_IDENTITY_TOKEN environment variable
+	// (or its context override) before falling back to `gcloud`.
+	IdentityToken string
+}
+
+func (g *GCPAuth) Authenticate(ctx context.Context, config *DelegatedTokenConfig) (*DelegatedTokenCredentials, error) {
+	if config == nil || config.OrgUUID == "" {
+		return nil, fmt.Errorf("missing org UUID in config")
+	}
+
+	proof, err := g.GetIdentityToken(ctx, config.OrgUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetDelegatedToken(ctx, config.OrgUUID, proof)
+}
+
+// GetIdentityToken resolves the GCP identity token serving as the exchange
+// proof: the IdentityToken field, then the DD_GCP_IDENTITY_TOKEN environment
+// variable (with its context override), then `gcloud`.
+func (g *GCPAuth) GetIdentityToken(ctx context.Context, orgUUID string) (string, error) {
+	if g.IdentityToken != "" {
+		return g.IdentityToken, nil
+	}
+	if token := gcpTokenFromContextOrEnv(ctx); token != "" {
+		return token, nil
+	}
+	return g.mintIdentityToken(ctx, orgUUID)
+}
+
+// mintIdentityToken invokes `gcloud auth print-identity-token` with the
+// Datadog org audience. Impersonation of a service account is required:
+// `gcloud` rejects `--audiences` for user credentials.
+func (g *GCPAuth) mintIdentityToken(ctx context.Context, orgUUID string) (string, error) {
+	if g.ImpersonateServiceAccount == "" {
+		return "", fmt.Errorf("missing service account to impersonate: set GCPAuth.ImpersonateServiceAccount or provide a pre-minted identity token via GCPAuth.IdentityToken or %s", GCPIdentityTokenName)
+	}
+	if _, err := exec.LookPath("gcloud"); err != nil {
+		return "", fmt.Errorf("`gcloud` not found on PATH (install the Google Cloud CLI and run `gcloud auth login`), or provide a pre-minted identity token")
+	}
+	args := gcloudIdentityTokenArgs(g.ImpersonateServiceAccount, gcpAudiencePrefix+orgUUID)
+	out, err := exec.CommandContext(ctx, "gcloud", args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("gcloud auth print-identity-token: %w (run `gcloud auth login` first)", err)
+	}
+	token := strings.TrimSpace(string(out))
+	if token == "" {
+		return "", fmt.Errorf("gcloud auth print-identity-token returned an empty token")
+	}
+	return token, nil
+}
+
+// gcloudIdentityTokenArgs builds the `gcloud` invocation for minting an
+// identity token with the Datadog org audience and the service-account email
+// in the `email` claim. Factored out for testing.
+func gcloudIdentityTokenArgs(impersonate, audience string) []string {
+	return []string{
+		"auth", "print-identity-token",
+		"--audiences=" + audience,
+		"--impersonate-service-account=" + impersonate,
+		"--include-email",
+	}
+}
+
+// gcpTokenFromContextOrEnv reads a pre-minted identity token from the context
+// override (mirroring ContextAWSVariables), falling back to the environment.
+func gcpTokenFromContextOrEnv(ctx context.Context) string {
+	if keys, ok := ctx.Value(ContextGCPVariables).(map[string]string); ok {
+		if token, ok := keys[GCPIdentityTokenName]; ok {
+			return token
+		}
+	}
+	return os.Getenv(GCPIdentityTokenName)
+}

--- a/examples/datadog/gcp/main.go
+++ b/examples/datadog/gcp/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func main() {
+	ctx := datadog.NewDefaultContext(context.Background())
+	configuration := datadog.NewConfiguration()
+	configuration.DelegatedTokenConfig = &datadog.DelegatedTokenConfig{
+		OrgUUID: os.Getenv("DD_TEST_ORG_UUID"),
+		ProviderAuth: &datadog.GCPAuth{
+			// Minting via `gcloud` requires impersonating a service account:
+			// user identity tokens cannot set the custom `datadog/<org-uuid>`
+			// audience. Alternatively, pass a pre-minted identity token via
+			// GCPAuth.IdentityToken or the DD_GCP_IDENTITY_TOKEN environment
+			// variable to skip the `gcloud` invocation entirely.
+			ImpersonateServiceAccount: os.Getenv("DD_TEST_GCP_SA_EMAIL"),
+		},
+		Provider: datadog.ProviderGCP,
+	}
+	apiClient := datadog.NewAPIClient(configuration)
+
+	// Make example API call using the DelegatedTokenConfig
+	api := datadogV2.NewTeamsApi(apiClient)
+	resp, r, err := api.ListTeams(ctx, *datadogV2.NewListTeamsOptionalParameters())
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `TeamsApi.ListTeams`: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+
+	responseContent, _ := json.MarshalIndent(resp, "", "  ")
+	fmt.Fprintf(os.Stdout, "Response from `TeamsApi.ListTeams`:\n%s\n", responseContent)
+}

--- a/tests/api/delegated_token_testutil_test.go
+++ b/tests/api/delegated_token_testutil_test.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+)
+
+// delegatedTokenTestContext returns a context and DelegatedTokenConfig wired
+// so that GetDelegatedTokenUrl routes its POST /api/v2/delegated-token call at
+// the given test server, using the "{protocol}://{name}" server configuration
+// (index 1).
+func delegatedTokenTestContext(t *testing.T, server *httptest.Server, provider string) (context.Context, *datadog.DelegatedTokenConfig) {
+	t.Helper()
+
+	ctx := context.WithValue(context.Background(), datadog.ContextServerIndex, 1)
+	ctx = context.WithValue(ctx, datadog.ContextServerVariables, map[string]string{
+		"name":     server.URL[len("http://"):],
+		"protocol": "http",
+	})
+	ctx = context.WithValue(ctx, datadog.ContextDelegatedToken, &datadog.DelegatedTokenCredentials{})
+
+	cfg := &datadog.DelegatedTokenConfig{
+		OrgUUID:  "12345678-1234-1234-1234-123456789012",
+		Provider: provider,
+	}
+	return ctx, cfg
+}

--- a/tests/api/gcp_test.go
+++ b/tests/api/gcp_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+)
+
+func TestGCPAuthenticate(t *testing.T) {
+	type testCase struct {
+		name           string
+		auth           datadog.GCPAuth
+		envToken       string
+		expectedProof  string
+		expectErr      bool
+		expectErrParts []string
+	}
+
+	testCases := []testCase{
+		{
+			name:          "Pre-minted token from field",
+			auth:          datadog.GCPAuth{IdentityToken: "field.jwt.sig"},
+			expectedProof: "field.jwt.sig",
+		},
+		{
+			name:          "Pre-minted token from env",
+			auth:          datadog.GCPAuth{},
+			envToken:      "env.jwt.sig",
+			expectedProof: "env.jwt.sig",
+		},
+		{
+			name:           "No token and no impersonation fails",
+			auth:           datadog.GCPAuth{},
+			expectErr:      true,
+			expectErrParts: []string{"missing service account to impersonate"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envToken != "" {
+				t.Setenv(datadog.GCPIdentityTokenName, tc.envToken)
+			} else {
+				t.Setenv(datadog.GCPIdentityTokenName, "")
+				os.Unsetenv(datadog.GCPIdentityTokenName)
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/api/v2/delegated-token" {
+					t.Errorf("got path %q, want /api/v2/delegated-token", r.URL.Path)
+				}
+				if got := r.Header.Get("Authorization"); got != "Delegated "+tc.expectedProof {
+					t.Errorf("Authorization = %q, want %q", got, "Delegated "+tc.expectedProof)
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data":{"type":"delegated_token","attributes":{"access_token":"delegated.jwt.sig","expires":"1700000000"}}}`))
+			}))
+			defer server.Close()
+
+			ctx, cfg := delegatedTokenTestContext(t, server, datadog.ProviderGCP)
+			cfg.ProviderAuth = &tc.auth
+
+			creds, err := cfg.ProviderAuth.Authenticate(ctx, cfg)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error containing %v, got nil", tc.expectErrParts)
+				}
+				for _, part := range tc.expectErrParts {
+					if !strings.Contains(err.Error(), part) {
+						t.Errorf("error = %q, want it to contain %q", err.Error(), part)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Authenticate: %v", err)
+			}
+			if creds.DelegatedToken != "delegated.jwt.sig" {
+				t.Errorf("DelegatedToken = %q, want delegated.jwt.sig", creds.DelegatedToken)
+			}
+			if creds.DelegatedProof != tc.expectedProof {
+				t.Errorf("DelegatedProof = %q, want %q", creds.DelegatedProof, tc.expectedProof)
+			}
+		})
+	}
+}
+
+func TestGCPMintIdentityTokenRequiresImpersonation(t *testing.T) {
+	auth := datadog.GCPAuth{}
+	_, err := auth.GetIdentityToken(context.Background(), "org-uuid")
+	if err == nil || !strings.Contains(err.Error(), "missing service account to impersonate") {
+		t.Errorf("err = %v, want missing-impersonation error", err)
+	}
+}
+
+func TestGCPIdentityTokenPrefersFieldOverEnv(t *testing.T) {
+	t.Setenv(datadog.GCPIdentityTokenName, "env.jwt.sig")
+	auth := datadog.GCPAuth{IdentityToken: "field.jwt.sig"}
+	token, err := auth.GetIdentityToken(context.Background(), "org-uuid")
+	if err != nil {
+		t.Fatalf("GetIdentityToken: %v", err)
+	}
+	if token != "field.jwt.sig" {
+		t.Errorf("token = %q, want field.jwt.sig", token)
+	}
+}
+
+func TestGCPContextOverride(t *testing.T) {
+	t.Setenv(datadog.GCPIdentityTokenName, "env.jwt.sig")
+	ctx := context.WithValue(context.Background(), datadog.ContextGCPVariables, map[string]string{
+		datadog.GCPIdentityTokenName: "ctx.jwt.sig",
+	})
+	auth := datadog.GCPAuth{}
+	token, err := auth.GetIdentityToken(ctx, "org-uuid")
+	if err != nil {
+		t.Fatalf("GetIdentityToken: %v", err)
+	}
+	if token != "ctx.jwt.sig" {
+		t.Errorf("token = %q, want ctx.jwt.sig (context override wins over env)", token)
+	}
+}

--- a/tests/api/gcp_test.go
+++ b/tests/api/gcp_test.go
@@ -124,3 +124,82 @@ func TestGCPContextOverride(t *testing.T) {
 		t.Errorf("token = %q, want ctx.jwt.sig (context override wins over env)", token)
 	}
 }
+
+// writeGcloudShim installs a fake `gcloud` executable that records its argv to
+// argvFile and prints token on stdout, returning a directory to prepend to
+// PATH. This exercises the real mint path (mintIdentityToken, argument
+// construction, output handling) without requiring the gcloud CLI.
+func writeGcloudShim(t *testing.T, argvFile, token string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$@\" >> " + argvFile + "\n" +
+		"echo " + token + "\n"
+	path := dir + "/gcloud"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write gcloud shim: %v", err)
+	}
+	return dir
+}
+
+// TestGCPMintIdentityTokenViaShim drives the real mint path through a fake
+// gcloud and pins the invocation that builds the GCP audience contract: the
+// identity token must carry the datadog/<org-uuid> audience, the
+// impersonated service account, and --include-email so the email claim
+// identifies the SA.
+func TestGCPMintIdentityTokenViaShim(t *testing.T) {
+	argvFile := t.TempDir() + "/argv"
+	const token = "shim.jwt.sig"
+	shimDir := writeGcloudShim(t, argvFile, token)
+	t.Setenv("PATH", shimDir)
+
+	auth := datadog.GCPAuth{ImpersonateServiceAccount: "sa@project.iam.gserviceaccount.com"}
+	got, err := auth.GetIdentityToken(context.Background(), "org-9")
+	if err != nil {
+		t.Fatalf("GetIdentityToken: %v", err)
+	}
+	if got != token {
+		t.Errorf("token = %q, want %q", got, token)
+	}
+
+	argv, err := os.ReadFile(argvFile)
+	if err != nil {
+		t.Fatalf("read shim argv: %v", err)
+	}
+	wantArgs := []string{
+		"auth",
+		"print-identity-token",
+		"--audiences=datadog/org-9",
+		"--impersonate-service-account=sa@project.iam.gserviceaccount.com",
+		"--include-email",
+	}
+	gotArgs := strings.Split(strings.TrimSpace(string(argv)), "\n")
+	if len(gotArgs) != len(wantArgs) {
+		t.Fatalf("gcloud argv = %v, want %v", gotArgs, wantArgs)
+	}
+	for i := range wantArgs {
+		if gotArgs[i] != wantArgs[i] {
+			t.Errorf("gcloud argv[%d] = %q, want %q", i, gotArgs[i], wantArgs[i])
+		}
+	}
+}
+
+// TestGCPMintIdentityTokenShimError pins the error path: a failing gcloud
+// surfaces its stderr in the wrapped error.
+func TestGCPMintIdentityTokenShimError(t *testing.T) {
+	dir := t.TempDir()
+	script := "#!/bin/sh\necho 'permission denied' >&2\nexit 1\n"
+	if err := os.WriteFile(dir+"/gcloud", []byte(script), 0o755); err != nil {
+		t.Fatalf("write gcloud shim: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	auth := datadog.GCPAuth{ImpersonateServiceAccount: "sa@project.iam.gserviceaccount.com"}
+	_, err := auth.GetIdentityToken(context.Background(), "org-9")
+	if err == nil {
+		t.Fatal("expected error from failing gcloud shim")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("err = %v, want it to carry the CLI stderr", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `GCPAuth`, a `DelegatedTokenProvider` that exchanges a Google Cloud identity token for a Datadog delegated token, mirroring the existing `AWSAuth`.

## How it works

The identity token is sourced from (in order):

1. The `GCPAuth.IdentityToken` field (pre-minted token, used verbatim)
2. The `DD_GCP_IDENTITY_TOKEN` environment variable, or its `ContextGCPVariables` context override
3. Minted via `gcloud auth print-identity-token`

The proof is sent to `POST /api/v2/delegated-token` as `Authorization: Delegated <identity-token>` - the same endpoint and header shape the AWS provider uses.

## Minting requires impersonation

`gcloud` rejects `--audiences` for user credentials, and the delegated-token endpoint expects the custom `datadog/<org-uuid>` audience that pins the exchange to the requested org. Minting therefore requires `GCPAuth.ImpersonateServiceAccount` (a service account with `roles/iam.serviceAccountTokenCreator` permission), with `--include-email` so the `email` claim carries the SA identity the servicer maps.

## Generator mirroring

- `gcp.j2` registered in `cli.py` `extra_files` so `GCPAuth` survives regeneration
- `ContextGCPVariables` + `DD_GCP_IDENTITY_TOKEN` env pickup mirrored in `configuration.j2`
- `example_gcp.j2` registered in `conftest.py` `DATADOG_EXAMPLES_J2`, writing `examples/datadog/gcp/main.go`

Template renders verified byte-identical to the checked-in files (`poetry run pytest`: 4815 passed).

## Usage

```go
configuration := datadog.NewConfiguration()
configuration.DelegatedTokenConfig = &datadog.DelegatedTokenConfig{
    OrgUUID: orgUUID,
    ProviderAuth: &datadog.GCPAuth{
        ImpersonateServiceAccount: "sa@project.iam.gserviceaccount.com",
    },
    Provider: datadog.ProviderGCP,
}
```

Strong inspiration taken from ddoghq/dd-source#88270 (wif-test GCP provider).

## Testing

`tests/api/gcp_test.go`: exchange contract (POST path, `Delegated` header, response parsing), env/context override precedence, missing-impersonation error, and hermetic PATH-shim tests driving the real mint path (argv/audience contract, token passthrough, CLI stderr error path). All `tests/api` pass; `go build ./api/...`, `go vet ./api/datadog/`, `go build ./examples/datadog/...` clean.

## Merge-order note

If PR #4591 (Azure) merges after this one, it carries small textual conflicts in `api/datadog/configuration.go`, `.generator/src/generator/templates/configuration.j2`, `.generator/src/generator/cli.py` (extra_files map), and `.generator/conftest.py` (DATADOG_EXAMPLES_J2 dict) - both PRs add adjacent hunks at the same anchors. All conflicts are mechanical (both hunks coexist verbatim; trailing-comma fixes in the two Python dicts). `tests/api/delegated_token_testutil_test.go` is byte-identical on both branches and merges as a no-op.

