### PR TITLE
Add Azure delegated token authentication provider

### DIFF
--- a/.generator/conftest.py
+++ b/.generator/conftest.py
@@ -71,7 +71,8 @@ JINJA_ENV.globals["given_variables"] = given_variables
 
 GO_EXAMPLE_J2 = JINJA_ENV.get_template("example.j2")
 DATADOG_EXAMPLES_J2 = {
-    "aws.go": JINJA_ENV.get_template("example_aws.j2")
+    "aws.go": JINJA_ENV.get_template("example_aws.j2"),
+    "azure/main.go": JINJA_ENV.get_template("example_azure.j2")
 }
 
 

--- a/.generator/src/generator/cli.py
+++ b/.generator/src/generator/cli.py
@@ -68,6 +68,7 @@ def cli(specs, output):
 
     extra_files = {
         "aws.go": env.get_template("aws.j2"),
+        "azure.go": env.get_template("azure.j2"),
         "client.go": env.get_template("client.j2"),
         "configuration.go": env.get_template("configuration.j2"),
         "delegated_auth.go": env.get_template("delegated_auth.j2"),

--- a/.generator/src/generator/templates/azure.j2
+++ b/.generator/src/generator/templates/azure.j2
@@ -1,0 +1,111 @@
+{% include "partial_header.j2" %}
+package {{ common_package_name }}
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+const ProviderAzure = "azure"
+
+// AzureAccessTokenName is the environment variable carrying a pre-minted
+// Azure/Entra ID access token, used instead of invoking `az`.
+const AzureAccessTokenName = "DD_AZURE_ACCESS_TOKEN"
+
+// AzureAuth exchanges a Microsoft Entra ID (Azure) access token for a Datadog
+// delegated token.
+type AzureAuth struct {
+	// Resource is the optional resource/audience passed to
+	// `az account get-access-token --resource`. When empty, `az` uses its
+	// default resource.
+	Resource string
+
+	// AccessToken is an optional pre-minted access token used verbatim as the
+	// exchange proof, bypassing the `az` invocation. When empty, the token is
+	// sourced from the DD_AZURE_ACCESS_TOKEN environment variable (or its
+	// context override) before falling back to `az`.
+	AccessToken string
+}
+
+func (a *AzureAuth) Authenticate(ctx context.Context, config *DelegatedTokenConfig) (*DelegatedTokenCredentials, error) {
+	if config == nil || config.OrgUUID == "" {
+		return nil, fmt.Errorf("missing org UUID in config")
+	}
+
+	accessToken, err := a.GetAccessToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Org routing: the delegated-token servicer splits the proof on the last
+	// ":" (JWTs contain no colons) and treats the suffix as the org UUID.
+	proof := azureDelegatedProof(accessToken, config.OrgUUID)
+
+	return GetDelegatedToken(ctx, config.OrgUUID, proof)
+}
+
+// azureDelegatedProof appends the org-UUID routing suffix to the access token.
+// Factored out for testing.
+func azureDelegatedProof(accessToken, orgUUID string) string {
+	return accessToken + ":" + orgUUID
+}
+
+// GetAccessToken resolves the Azure access token serving as the exchange
+// proof: the AccessToken field, then the DD_AZURE_ACCESS_TOKEN environment
+// variable (with its context override), then `az`.
+func (a *AzureAuth) GetAccessToken(ctx context.Context) (string, error) {
+	if a.AccessToken != "" {
+		return a.AccessToken, nil
+	}
+	if token := azureTokenFromContextOrEnv(ctx); token != "" {
+		return token, nil
+	}
+	return a.mintAccessToken(ctx)
+}
+
+// mintAccessToken invokes `az account get-access-token` and extracts the raw
+// access token from the JSON output.
+func (a *AzureAuth) mintAccessToken(ctx context.Context) (string, error) {
+	if _, err := exec.LookPath("az"); err != nil {
+		return "", fmt.Errorf("`az` not found on PATH (install the Azure CLI and run `az login`), or provide a pre-minted access token via AzureAuth.AccessToken or %s", AzureAccessTokenName)
+	}
+	out, err := exec.CommandContext(ctx, "az", azAccessTokenArgs(a.Resource)...).Output()
+	if err != nil {
+		return "", fmt.Errorf("az account get-access-token: %w (run `az login` first)", err)
+	}
+	var result struct {
+		AccessToken string `json:"accessToken"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return "", fmt.Errorf("parse az account get-access-token output: %w", err)
+	}
+	if result.AccessToken == "" {
+		return "", fmt.Errorf("az account get-access-token returned no accessToken")
+	}
+	return result.AccessToken, nil
+}
+
+// azAccessTokenArgs builds the `az` invocation for minting an access token.
+// JSON output is requested so the token is extracted without depending on the
+// JMESPath `--query` behavior across `az` versions. Factored out for testing.
+func azAccessTokenArgs(resource string) []string {
+	args := []string{"account", "get-access-token", "--output", "json"}
+	if resource != "" {
+		args = append(args, "--resource", resource)
+	}
+	return args
+}
+
+// azureTokenFromContextOrEnv reads a pre-minted access token from the context
+// override (mirroring ContextAWSVariables), falling back to the environment.
+func azureTokenFromContextOrEnv(ctx context.Context) string {
+	if keys, ok := ctx.Value(ContextAzureVariables).(map[string]string); ok {
+		if token, ok := keys[AzureAccessTokenName]; ok {
+			return token
+		}
+	}
+	return os.Getenv(AzureAccessTokenName)
+}

--- a/.generator/src/generator/templates/azure.j2
+++ b/.generator/src/generator/templates/azure.j2
@@ -3,33 +3,32 @@ package {{ common_package_name }}
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 )
 
 const ProviderAzure = "azure"
 
 // AzureAccessTokenName is the environment variable carrying a pre-minted
-// Azure/Entra ID access token, used instead of invoking `az`.
+// Azure/Entra ID access token.
 const AzureAccessTokenName = "DD_AZURE_ACCESS_TOKEN"
+
+// AzureTokenSource returns a current Microsoft Entra ID access token.
+type AzureTokenSource func(context.Context) (string, error)
 
 // AzureAuth exchanges a Microsoft Entra ID (Azure) access token for a Datadog
 // delegated token.
 type AzureAuth struct {
-	// Resource is the optional resource/audience passed to
-	// `az account get-access-token --resource`. When empty, `az` uses its
-	// default resource.
-	Resource string
-
 	// AccessToken is an optional pre-minted access token used verbatim as the
-	// exchange proof, bypassing the `az` invocation. When empty, the token is
-	// sourced from the DD_AZURE_ACCESS_TOKEN environment variable (or its
-	// context override) before falling back to `az`.
+	// exchange proof. When empty, the token is sourced from the
+	// DD_AZURE_ACCESS_TOKEN environment variable (or its context override)
+	// before falling back to TokenSource.
 	AccessToken string
+
+	// TokenSource optionally acquires Azure access tokens when no explicit token
+	// is configured. It owns credential selection, tenant, audience or scope,
+	// and token renewal.
+	TokenSource AzureTokenSource
 }
 
 func (a *AzureAuth) Authenticate(ctx context.Context, config *DelegatedTokenConfig) (*DelegatedTokenCredentials, error) {
@@ -56,7 +55,7 @@ func azureDelegatedProof(accessToken, orgUUID string) string {
 
 // GetAccessToken resolves the Azure access token serving as the exchange
 // proof: the AccessToken field, then the DD_AZURE_ACCESS_TOKEN environment
-// variable (with its context override), then `az`.
+// variable (with its context override), then TokenSource.
 func (a *AzureAuth) GetAccessToken(ctx context.Context) (string, error) {
 	if a.AccessToken != "" {
 		return a.AccessToken, nil
@@ -64,44 +63,18 @@ func (a *AzureAuth) GetAccessToken(ctx context.Context) (string, error) {
 	if token := azureTokenFromContextOrEnv(ctx); token != "" {
 		return token, nil
 	}
-	return a.mintAccessToken(ctx)
-}
-
-// mintAccessToken invokes `az account get-access-token` and extracts the raw
-// access token from the JSON output.
-func (a *AzureAuth) mintAccessToken(ctx context.Context) (string, error) {
-	if _, err := exec.LookPath("az"); err != nil {
-		return "", fmt.Errorf("`az` not found on PATH (install the Azure CLI and run `az login`), or provide a pre-minted access token via AzureAuth.AccessToken or %s", AzureAccessTokenName)
+	if a.TokenSource == nil {
+		return "", fmt.Errorf("azure access token is not configured: set AzureAuth.AccessToken, %s, or AzureAuth.TokenSource", AzureAccessTokenName)
 	}
-	out, err := exec.CommandContext(ctx, "az", azAccessTokenArgs(a.Resource)...).Output()
+
+	token, err := a.TokenSource(ctx)
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
-			return "", fmt.Errorf("az account get-access-token: %w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
-		}
-		return "", fmt.Errorf("az account get-access-token: %w (run `az login` first)", err)
+		return "", fmt.Errorf("azure token source: %w", err)
 	}
-	var result struct {
-		AccessToken string `json:"accessToken"`
+	if token == "" {
+		return "", fmt.Errorf("azure token source returned an empty access token")
 	}
-	if err := json.Unmarshal(out, &result); err != nil {
-		return "", fmt.Errorf("parse az account get-access-token output: %w", err)
-	}
-	if result.AccessToken == "" {
-		return "", fmt.Errorf("az account get-access-token returned no accessToken")
-	}
-	return result.AccessToken, nil
-}
-
-// azAccessTokenArgs builds the `az` invocation for minting an access token.
-// JSON output is requested so the token is extracted without depending on the
-// JMESPath `--query` behavior across `az` versions.
-func azAccessTokenArgs(resource string) []string {
-	args := []string{"account", "get-access-token", "--output", "json"}
-	if resource != "" {
-		args = append(args, "--resource", resource)
-	}
-	return args
+	return token, nil
 }
 
 // azureTokenFromContextOrEnv reads a pre-minted access token from the context

--- a/.generator/src/generator/templates/azure.j2
+++ b/.generator/src/generator/templates/azure.j2
@@ -4,9 +4,11 @@ package {{ common_package_name }}
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 const ProviderAzure = "azure"
@@ -48,7 +50,6 @@ func (a *AzureAuth) Authenticate(ctx context.Context, config *DelegatedTokenConf
 }
 
 // azureDelegatedProof appends the org-UUID routing suffix to the access token.
-// Factored out for testing.
 func azureDelegatedProof(accessToken, orgUUID string) string {
 	return accessToken + ":" + orgUUID
 }
@@ -74,6 +75,10 @@ func (a *AzureAuth) mintAccessToken(ctx context.Context) (string, error) {
 	}
 	out, err := exec.CommandContext(ctx, "az", azAccessTokenArgs(a.Resource)...).Output()
 	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			return "", fmt.Errorf("az account get-access-token: %w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
 		return "", fmt.Errorf("az account get-access-token: %w (run `az login` first)", err)
 	}
 	var result struct {
@@ -90,7 +95,7 @@ func (a *AzureAuth) mintAccessToken(ctx context.Context) (string, error) {
 
 // azAccessTokenArgs builds the `az` invocation for minting an access token.
 // JSON output is requested so the token is extracted without depending on the
-// JMESPath `--query` behavior across `az` versions. Factored out for testing.
+// JMESPath `--query` behavior across `az` versions.
 func azAccessTokenArgs(resource string) []string {
 	args := []string{"account", "get-access-token", "--output", "json"}
 	if resource != "" {

--- a/.generator/src/generator/templates/azure.j2
+++ b/.generator/src/generator/templates/azure.j2
@@ -41,8 +41,7 @@ func (a *AzureAuth) Authenticate(ctx context.Context, config *DelegatedTokenConf
 		return nil, err
 	}
 
-	// Org routing: the delegated-token servicer splits the proof on the last
-	// ":" (JWTs contain no colons) and treats the suffix as the org UUID.
+	// Include the organization UUID required by Azure delegated authentication.
 	proof := azureDelegatedProof(accessToken, config.OrgUUID)
 
 	return GetDelegatedToken(ctx, config.OrgUUID, proof)

--- a/.generator/src/generator/templates/configuration.j2
+++ b/.generator/src/generator/templates/configuration.j2
@@ -45,6 +45,11 @@ var (
 	// ContextAWSVariables takes AWS credentials as authentication for the request.
 	ContextAWSVariables = contextKey("awsVariables")
 
+	// ContextAzureVariables takes Azure credentials (pre-minted access tokens)
+	// as authentication for the request. Keys use the provider-specific name
+	// constants, e.g. datadog.AzureAccessTokenName.
+	ContextAzureVariables = contextKey("azureVariables")
+
 	// ContextHttpSignatureAuth takes HttpSignatureAuth as authentication for the request.
 	ContextHttpSignatureAuth = contextKey("httpsignature")
 
@@ -420,6 +425,16 @@ func NewDefaultContext(ctx context.Context) context.Context {
 		ctx,
 		ContextAWSVariables,
 		awsKeys,
+	)
+
+	azureKeys := make(map[string]string)
+	if azureToken, ok := os.LookupEnv(AzureAccessTokenName); ok {
+		azureKeys[AzureAccessTokenName] = azureToken
+	}
+	ctx = context.WithValue(
+		ctx,
+		ContextAzureVariables,
+		azureKeys,
 	)
 
 	ctx = context.WithValue(

--- a/.generator/src/generator/templates/example_azure.j2
+++ b/.generator/src/generator/templates/example_azure.j2
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func main() {
+	ctx := datadog.NewDefaultContext(context.Background())
+	configuration := datadog.NewConfiguration()
+	configuration.DelegatedTokenConfig = &datadog.DelegatedTokenConfig{
+		OrgUUID:      os.Getenv("DD_TEST_ORG_UUID"),
+		ProviderAuth: &datadog.AzureAuth{},
+		Provider:     datadog.ProviderAzure,
+	}
+	// AzureAuth pulls the access token from `az account get-access-token`.
+	// To skip the `az` invocation, pass a pre-minted token via
+	// AzureAuth.AccessToken or the DD_AZURE_ACCESS_TOKEN environment variable,
+	// and optionally set Resource for a non-default `az --resource`.
+	apiClient := datadog.NewAPIClient(configuration)
+
+	// Make example API call using the DelegatedTokenConfig
+	api := datadogV2.NewTeamsApi(apiClient)
+	resp, r, err := api.ListTeams(ctx, *datadogV2.NewListTeamsOptionalParameters())
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `TeamsApi.ListTeams`: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+
+	responseContent, _ := json.MarshalIndent(resp, "", "  ")
+	fmt.Fprintf(os.Stdout, "Response from `TeamsApi.ListTeams`:\n%s\n", responseContent)
+}
+

--- a/.generator/src/generator/templates/example_azure.j2
+++ b/.generator/src/generator/templates/example_azure.j2
@@ -13,15 +13,20 @@ import (
 func main() {
 	ctx := datadog.NewDefaultContext(context.Background())
 	configuration := datadog.NewConfiguration()
+	azureAuth := &datadog.AzureAuth{}
+	// Set AzureAuth.AccessToken or DD_AZURE_ACCESS_TOKEN for a pre-minted token.
+	// To delegate acquisition and renewal to the application's Azure credential
+	// provider, assign AzureAuth.TokenSource to a function with the signature
+	// func(context.Context) (string, error).
+	//
+	// The token source chooses the credential, tenant, and audience or scope. It
+	// may adapt Managed Identity, Workload Identity, or an explicitly configured
+	// Azure CLI credential; AzureAuth does not select or invoke one.
 	configuration.DelegatedTokenConfig = &datadog.DelegatedTokenConfig{
 		OrgUUID:      os.Getenv("DD_TEST_ORG_UUID"),
-		ProviderAuth: &datadog.AzureAuth{},
+		ProviderAuth: azureAuth,
 		Provider:     datadog.ProviderAzure,
 	}
-	// AzureAuth pulls the access token from `az account get-access-token`.
-	// To skip the `az` invocation, pass a pre-minted token via
-	// AzureAuth.AccessToken or the DD_AZURE_ACCESS_TOKEN environment variable,
-	// and optionally set Resource for a non-default `az --resource`.
 	apiClient := datadog.NewAPIClient(configuration)
 
 	// Make example API call using the DelegatedTokenConfig

--- a/api/datadog/azure.go
+++ b/api/datadog/azure.go
@@ -44,8 +44,7 @@ func (a *AzureAuth) Authenticate(ctx context.Context, config *DelegatedTokenConf
 		return nil, err
 	}
 
-	// Org routing: the delegated-token servicer splits the proof on the last
-	// ":" (JWTs contain no colons) and treats the suffix as the org UUID.
+	// Include the organization UUID required by Azure delegated authentication.
 	proof := azureDelegatedProof(accessToken, config.OrgUUID)
 
 	return GetDelegatedToken(ctx, config.OrgUUID, proof)

--- a/api/datadog/azure.go
+++ b/api/datadog/azure.go
@@ -1,0 +1,114 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+package datadog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+const ProviderAzure = "azure"
+
+// AzureAccessTokenName is the environment variable carrying a pre-minted
+// Azure/Entra ID access token, used instead of invoking `az`.
+const AzureAccessTokenName = "DD_AZURE_ACCESS_TOKEN"
+
+// AzureAuth exchanges a Microsoft Entra ID (Azure) access token for a Datadog
+// delegated token.
+type AzureAuth struct {
+	// Resource is the optional resource/audience passed to
+	// `az account get-access-token --resource`. When empty, `az` uses its
+	// default resource.
+	Resource string
+
+	// AccessToken is an optional pre-minted access token used verbatim as the
+	// exchange proof, bypassing the `az` invocation. When empty, the token is
+	// sourced from the DD_AZURE_ACCESS_TOKEN environment variable (or its
+	// context override) before falling back to `az`.
+	AccessToken string
+}
+
+func (a *AzureAuth) Authenticate(ctx context.Context, config *DelegatedTokenConfig) (*DelegatedTokenCredentials, error) {
+	if config == nil || config.OrgUUID == "" {
+		return nil, fmt.Errorf("missing org UUID in config")
+	}
+
+	accessToken, err := a.GetAccessToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Org routing: the delegated-token servicer splits the proof on the last
+	// ":" (JWTs contain no colons) and treats the suffix as the org UUID.
+	proof := azureDelegatedProof(accessToken, config.OrgUUID)
+
+	return GetDelegatedToken(ctx, config.OrgUUID, proof)
+}
+
+// azureDelegatedProof appends the org-UUID routing suffix to the access token.
+// Factored out for testing.
+func azureDelegatedProof(accessToken, orgUUID string) string {
+	return accessToken + ":" + orgUUID
+}
+
+// GetAccessToken resolves the Azure access token serving as the exchange
+// proof: the AccessToken field, then the DD_AZURE_ACCESS_TOKEN environment
+// variable (with its context override), then `az`.
+func (a *AzureAuth) GetAccessToken(ctx context.Context) (string, error) {
+	if a.AccessToken != "" {
+		return a.AccessToken, nil
+	}
+	if token := azureTokenFromContextOrEnv(ctx); token != "" {
+		return token, nil
+	}
+	return a.mintAccessToken(ctx)
+}
+
+// mintAccessToken invokes `az account get-access-token` and extracts the raw
+// access token from the JSON output.
+func (a *AzureAuth) mintAccessToken(ctx context.Context) (string, error) {
+	if _, err := exec.LookPath("az"); err != nil {
+		return "", fmt.Errorf("`az` not found on PATH (install the Azure CLI and run `az login`), or provide a pre-minted access token via AzureAuth.AccessToken or %s", AzureAccessTokenName)
+	}
+	out, err := exec.CommandContext(ctx, "az", azAccessTokenArgs(a.Resource)...).Output()
+	if err != nil {
+		return "", fmt.Errorf("az account get-access-token: %w (run `az login` first)", err)
+	}
+	var result struct {
+		AccessToken string `json:"accessToken"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return "", fmt.Errorf("parse az account get-access-token output: %w", err)
+	}
+	if result.AccessToken == "" {
+		return "", fmt.Errorf("az account get-access-token returned no accessToken")
+	}
+	return result.AccessToken, nil
+}
+
+// azAccessTokenArgs builds the `az` invocation for minting an access token.
+// JSON output is requested so the token is extracted without depending on the
+// JMESPath `--query` behavior across `az` versions. Factored out for testing.
+func azAccessTokenArgs(resource string) []string {
+	args := []string{"account", "get-access-token", "--output", "json"}
+	if resource != "" {
+		args = append(args, "--resource", resource)
+	}
+	return args
+}
+
+// azureTokenFromContextOrEnv reads a pre-minted access token from the context
+// override (mirroring ContextAWSVariables), falling back to the environment.
+func azureTokenFromContextOrEnv(ctx context.Context) string {
+	if keys, ok := ctx.Value(ContextAzureVariables).(map[string]string); ok {
+		if token, ok := keys[AzureAccessTokenName]; ok {
+			return token
+		}
+	}
+	return os.Getenv(AzureAccessTokenName)
+}

--- a/api/datadog/azure.go
+++ b/api/datadog/azure.go
@@ -6,33 +6,32 @@ package datadog
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 )
 
 const ProviderAzure = "azure"
 
 // AzureAccessTokenName is the environment variable carrying a pre-minted
-// Azure/Entra ID access token, used instead of invoking `az`.
+// Azure/Entra ID access token.
 const AzureAccessTokenName = "DD_AZURE_ACCESS_TOKEN"
+
+// AzureTokenSource returns a current Microsoft Entra ID access token.
+type AzureTokenSource func(context.Context) (string, error)
 
 // AzureAuth exchanges a Microsoft Entra ID (Azure) access token for a Datadog
 // delegated token.
 type AzureAuth struct {
-	// Resource is the optional resource/audience passed to
-	// `az account get-access-token --resource`. When empty, `az` uses its
-	// default resource.
-	Resource string
-
 	// AccessToken is an optional pre-minted access token used verbatim as the
-	// exchange proof, bypassing the `az` invocation. When empty, the token is
-	// sourced from the DD_AZURE_ACCESS_TOKEN environment variable (or its
-	// context override) before falling back to `az`.
+	// exchange proof. When empty, the token is sourced from the
+	// DD_AZURE_ACCESS_TOKEN environment variable (or its context override)
+	// before falling back to TokenSource.
 	AccessToken string
+
+	// TokenSource optionally acquires Azure access tokens when no explicit token
+	// is configured. It owns credential selection, tenant, audience or scope,
+	// and token renewal.
+	TokenSource AzureTokenSource
 }
 
 func (a *AzureAuth) Authenticate(ctx context.Context, config *DelegatedTokenConfig) (*DelegatedTokenCredentials, error) {
@@ -59,7 +58,7 @@ func azureDelegatedProof(accessToken, orgUUID string) string {
 
 // GetAccessToken resolves the Azure access token serving as the exchange
 // proof: the AccessToken field, then the DD_AZURE_ACCESS_TOKEN environment
-// variable (with its context override), then `az`.
+// variable (with its context override), then TokenSource.
 func (a *AzureAuth) GetAccessToken(ctx context.Context) (string, error) {
 	if a.AccessToken != "" {
 		return a.AccessToken, nil
@@ -67,44 +66,18 @@ func (a *AzureAuth) GetAccessToken(ctx context.Context) (string, error) {
 	if token := azureTokenFromContextOrEnv(ctx); token != "" {
 		return token, nil
 	}
-	return a.mintAccessToken(ctx)
-}
-
-// mintAccessToken invokes `az account get-access-token` and extracts the raw
-// access token from the JSON output.
-func (a *AzureAuth) mintAccessToken(ctx context.Context) (string, error) {
-	if _, err := exec.LookPath("az"); err != nil {
-		return "", fmt.Errorf("`az` not found on PATH (install the Azure CLI and run `az login`), or provide a pre-minted access token via AzureAuth.AccessToken or %s", AzureAccessTokenName)
+	if a.TokenSource == nil {
+		return "", fmt.Errorf("azure access token is not configured: set AzureAuth.AccessToken, %s, or AzureAuth.TokenSource", AzureAccessTokenName)
 	}
-	out, err := exec.CommandContext(ctx, "az", azAccessTokenArgs(a.Resource)...).Output()
+
+	token, err := a.TokenSource(ctx)
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
-			return "", fmt.Errorf("az account get-access-token: %w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
-		}
-		return "", fmt.Errorf("az account get-access-token: %w (run `az login` first)", err)
+		return "", fmt.Errorf("azure token source: %w", err)
 	}
-	var result struct {
-		AccessToken string `json:"accessToken"`
+	if token == "" {
+		return "", fmt.Errorf("azure token source returned an empty access token")
 	}
-	if err := json.Unmarshal(out, &result); err != nil {
-		return "", fmt.Errorf("parse az account get-access-token output: %w", err)
-	}
-	if result.AccessToken == "" {
-		return "", fmt.Errorf("az account get-access-token returned no accessToken")
-	}
-	return result.AccessToken, nil
-}
-
-// azAccessTokenArgs builds the `az` invocation for minting an access token.
-// JSON output is requested so the token is extracted without depending on the
-// JMESPath `--query` behavior across `az` versions.
-func azAccessTokenArgs(resource string) []string {
-	args := []string{"account", "get-access-token", "--output", "json"}
-	if resource != "" {
-		args = append(args, "--resource", resource)
-	}
-	return args
+	return token, nil
 }
 
 // azureTokenFromContextOrEnv reads a pre-minted access token from the context

--- a/api/datadog/azure.go
+++ b/api/datadog/azure.go
@@ -7,9 +7,11 @@ package datadog
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 const ProviderAzure = "azure"
@@ -77,6 +79,10 @@ func (a *AzureAuth) mintAccessToken(ctx context.Context) (string, error) {
 	}
 	out, err := exec.CommandContext(ctx, "az", azAccessTokenArgs(a.Resource)...).Output()
 	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			return "", fmt.Errorf("az account get-access-token: %w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
 		return "", fmt.Errorf("az account get-access-token: %w (run `az login` first)", err)
 	}
 	var result struct {

--- a/api/datadog/azure.go
+++ b/api/datadog/azure.go
@@ -53,7 +53,6 @@ func (a *AzureAuth) Authenticate(ctx context.Context, config *DelegatedTokenConf
 }
 
 // azureDelegatedProof appends the org-UUID routing suffix to the access token.
-// Factored out for testing.
 func azureDelegatedProof(accessToken, orgUUID string) string {
 	return accessToken + ":" + orgUUID
 }
@@ -99,7 +98,7 @@ func (a *AzureAuth) mintAccessToken(ctx context.Context) (string, error) {
 
 // azAccessTokenArgs builds the `az` invocation for minting an access token.
 // JSON output is requested so the token is extracted without depending on the
-// JMESPath `--query` behavior across `az` versions. Factored out for testing.
+// JMESPath `--query` behavior across `az` versions.
 func azAccessTokenArgs(resource string) []string {
 	args := []string{"account", "get-access-token", "--output", "json"}
 	if resource != "" {

--- a/api/datadog/configuration.go
+++ b/api/datadog/configuration.go
@@ -48,6 +48,11 @@ var (
 	// ContextAWSVariables takes AWS credentials as authentication for the request.
 	ContextAWSVariables = contextKey("awsVariables")
 
+	// ContextAzureVariables takes Azure credentials (pre-minted access tokens)
+	// as authentication for the request. Keys use the provider-specific name
+	// constants, e.g. datadog.AzureAccessTokenName.
+	ContextAzureVariables = contextKey("azureVariables")
+
 	// ContextHttpSignatureAuth takes HttpSignatureAuth as authentication for the request.
 	ContextHttpSignatureAuth = contextKey("httpsignature")
 
@@ -1587,6 +1592,16 @@ func NewDefaultContext(ctx context.Context) context.Context {
 		ctx,
 		ContextAWSVariables,
 		awsKeys,
+	)
+
+	azureKeys := make(map[string]string)
+	if azureToken, ok := os.LookupEnv(AzureAccessTokenName); ok {
+		azureKeys[AzureAccessTokenName] = azureToken
+	}
+	ctx = context.WithValue(
+		ctx,
+		ContextAzureVariables,
+		azureKeys,
 	)
 
 	ctx = context.WithValue(

--- a/examples/datadog/azure/main.go
+++ b/examples/datadog/azure/main.go
@@ -13,15 +13,20 @@ import (
 func main() {
 	ctx := datadog.NewDefaultContext(context.Background())
 	configuration := datadog.NewConfiguration()
+	azureAuth := &datadog.AzureAuth{}
+	// Set AzureAuth.AccessToken or DD_AZURE_ACCESS_TOKEN for a pre-minted token.
+	// To delegate acquisition and renewal to the application's Azure credential
+	// provider, assign AzureAuth.TokenSource to a function with the signature
+	// func(context.Context) (string, error).
+	//
+	// The token source chooses the credential, tenant, and audience or scope. It
+	// may adapt Managed Identity, Workload Identity, or an explicitly configured
+	// Azure CLI credential; AzureAuth does not select or invoke one.
 	configuration.DelegatedTokenConfig = &datadog.DelegatedTokenConfig{
 		OrgUUID:      os.Getenv("DD_TEST_ORG_UUID"),
-		ProviderAuth: &datadog.AzureAuth{},
+		ProviderAuth: azureAuth,
 		Provider:     datadog.ProviderAzure,
 	}
-	// AzureAuth pulls the access token from `az account get-access-token`.
-	// To skip the `az` invocation, pass a pre-minted token via
-	// AzureAuth.AccessToken or the DD_AZURE_ACCESS_TOKEN environment variable,
-	// and optionally set Resource for a non-default `az --resource`.
 	apiClient := datadog.NewAPIClient(configuration)
 
 	// Make example API call using the DelegatedTokenConfig

--- a/examples/datadog/azure/main.go
+++ b/examples/datadog/azure/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func main() {
+	ctx := datadog.NewDefaultContext(context.Background())
+	configuration := datadog.NewConfiguration()
+	configuration.DelegatedTokenConfig = &datadog.DelegatedTokenConfig{
+		OrgUUID:      os.Getenv("DD_TEST_ORG_UUID"),
+		ProviderAuth: &datadog.AzureAuth{},
+		Provider:     datadog.ProviderAzure,
+	}
+	// AzureAuth pulls the access token from `az account get-access-token`.
+	// To skip the `az` invocation, pass a pre-minted token via
+	// AzureAuth.AccessToken or the DD_AZURE_ACCESS_TOKEN environment variable,
+	// and optionally set Resource for a non-default `az --resource`.
+	apiClient := datadog.NewAPIClient(configuration)
+
+	// Make example API call using the DelegatedTokenConfig
+	api := datadogV2.NewTeamsApi(apiClient)
+	resp, r, err := api.ListTeams(ctx, *datadogV2.NewListTeamsOptionalParameters())
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `TeamsApi.ListTeams`: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+
+	responseContent, _ := json.MarshalIndent(resp, "", "  ")
+	fmt.Fprintf(os.Stdout, "Response from `TeamsApi.ListTeams`:\n%s\n", responseContent)
+}

--- a/tests/api/azure_test.go
+++ b/tests/api/azure_test.go
@@ -33,6 +33,15 @@ func TestAzureAuthenticate(t *testing.T) {
 			envToken:      "env.jwt.sig",
 			expectedProof: "env.jwt.sig:12345678-1234-1234-1234-123456789012",
 		},
+		{
+			// No token anywhere: with PATH emptied below,
+			// mintAccessToken's exec.LookPath fails deterministically
+			// without invoking a real `az` binary, so the case is hermetic.
+			name:           "No token and no az CLI fails",
+			auth:           datadog.AzureAuth{},
+			expectErr:      true,
+			expectErrParts: []string{"`az` not found on PATH"},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -42,6 +51,11 @@ func TestAzureAuthenticate(t *testing.T) {
 			} else {
 				t.Setenv(datadog.AzureAccessTokenName, "")
 				os.Unsetenv(datadog.AzureAccessTokenName)
+			}
+			if tc.expectErr {
+				// Empty PATH so exec.LookPath("az") fails deterministically
+				// on machines with the Azure CLI installed.
+				t.Setenv("PATH", "")
 			}
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tests/api/azure_test.go
+++ b/tests/api/azure_test.go
@@ -155,3 +155,101 @@ func TestAzureAuthenticateMissingOrgUUID(t *testing.T) {
 		t.Errorf("err = %v, want missing org UUID error", err)
 	}
 }
+
+// writeAzShim installs a fake `az` executable that records its argv to
+// argvFile and prints a JSON access-token response on stdout, returning a
+// directory to prepend to PATH. This exercises the real mint path
+// (mintAccessToken, argument construction, output parsing) without requiring
+// the az CLI.
+func writeAzShim(t *testing.T, argvFile, token string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$@\" >> " + argvFile + "\n" +
+		`echo '{"accessToken":"` + token + `"}'` + "\n"
+	path := dir + "/az"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write az shim: %v", err)
+	}
+	return dir
+}
+
+// TestAzureMintAccessTokenViaShim drives the real mint path through a fake az
+// and pins the invocation: JSON output (token extracted without depending on
+// JMESPath behavior across az versions) and no --resource when Resource is
+// unset.
+func TestAzureMintAccessTokenViaShim(t *testing.T) {
+	argvFile := t.TempDir() + "/argv"
+	const token = "shim.jwt.sig"
+	shimDir := writeAzShim(t, argvFile, token)
+	t.Setenv("PATH", shimDir)
+	t.Setenv(datadog.AzureAccessTokenName, "")
+	os.Unsetenv(datadog.AzureAccessTokenName)
+
+	auth := datadog.AzureAuth{}
+	got, err := auth.GetAccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("GetAccessToken: %v", err)
+	}
+	if got != token {
+		t.Errorf("token = %q, want %q", got, token)
+	}
+
+	argv, err := os.ReadFile(argvFile)
+	if err != nil {
+		t.Fatalf("read shim argv: %v", err)
+	}
+	wantArgs := []string{"account", "get-access-token", "--output", "json"}
+	gotArgs := strings.Split(strings.TrimSpace(string(argv)), "\n")
+	if len(gotArgs) != len(wantArgs) {
+		t.Fatalf("az argv = %v, want %v", gotArgs, wantArgs)
+	}
+	for i := range wantArgs {
+		if gotArgs[i] != wantArgs[i] {
+			t.Errorf("az argv[%d] = %q, want %q", i, gotArgs[i], wantArgs[i])
+		}
+	}
+}
+
+// TestAzureMintAccessTokenResourceArg pins the --resource passthrough.
+func TestAzureMintAccessTokenResourceArg(t *testing.T) {
+	argvFile := t.TempDir() + "/argv"
+	shimDir := writeAzShim(t, argvFile, "shim.jwt.sig")
+	t.Setenv("PATH", shimDir)
+	t.Setenv(datadog.AzureAccessTokenName, "")
+	os.Unsetenv(datadog.AzureAccessTokenName)
+
+	auth := datadog.AzureAuth{Resource: "https://management.azure.com/"}
+	if _, err := auth.GetAccessToken(context.Background()); err != nil {
+		t.Fatalf("GetAccessToken: %v", err)
+	}
+	argv, err := os.ReadFile(argvFile)
+	if err != nil {
+		t.Fatalf("read shim argv: %v", err)
+	}
+	if !strings.Contains(string(argv), "--resource") || !strings.Contains(string(argv), "https://management.azure.com/") {
+		t.Errorf("az argv = %q, want it to carry --resource with its value", string(argv))
+	}
+}
+
+// TestAzureMintAccessTokenShimError pins the error path: a failing az
+// surfaces its stderr in the wrapped error.
+func TestAzureMintAccessTokenShimError(t *testing.T) {
+	dir := t.TempDir()
+	script := "#!/bin/sh\necho 'run az login' >&2\nexit 1\n"
+	if err := os.WriteFile(dir+"/az", []byte(script), 0o755); err != nil {
+		t.Fatalf("write az shim: %v", err)
+	}
+	t.Setenv("PATH", dir)
+	t.Setenv(datadog.AzureAccessTokenName, "")
+	os.Unsetenv(datadog.AzureAccessTokenName)
+
+	auth := datadog.AzureAuth{}
+	_, err := auth.GetAccessToken(context.Background())
+	if err == nil {
+		t.Fatal("expected error from failing az shim")
+	}
+	if !strings.Contains(err.Error(), "run az login") {
+		t.Errorf("err = %v, want it to carry the CLI stderr", err)
+	}
+}

--- a/tests/api/azure_test.go
+++ b/tests/api/azure_test.go
@@ -1,0 +1,164 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+)
+
+// delegatedTokenTestContext returns a context and DelegatedTokenConfig wired
+// so that GetDelegatedTokenUrl routes its POST /api/v2/delegated-token call at
+// the given test server, using the "{protocol}://{name}" server configuration
+// (index 1).
+func delegatedTokenTestContext(t *testing.T, server *httptest.Server, provider string) (context.Context, *datadog.DelegatedTokenConfig) {
+	t.Helper()
+
+	ctx := context.WithValue(context.Background(), datadog.ContextServerIndex, 1)
+	ctx = context.WithValue(ctx, datadog.ContextServerVariables, map[string]string{
+		"name":     server.URL[len("http://"):],
+		"protocol": "http",
+	})
+	ctx = context.WithValue(ctx, datadog.ContextDelegatedToken, &datadog.DelegatedTokenCredentials{})
+
+	cfg := &datadog.DelegatedTokenConfig{
+		OrgUUID:  "12345678-1234-1234-1234-123456789012",
+		Provider: provider,
+	}
+	return ctx, cfg
+}
+
+func TestAzureAuthenticate(t *testing.T) {
+	type testCase struct {
+		name           string
+		auth           datadog.AzureAuth
+		envToken       string
+		expectedProof  string
+		expectErr      bool
+		expectErrParts []string
+	}
+
+	testCases := []testCase{
+		{
+			name:          "Pre-minted token from field",
+			auth:          datadog.AzureAuth{AccessToken: "field.jwt.sig"},
+			expectedProof: "field.jwt.sig:12345678-1234-1234-1234-123456789012",
+		},
+		{
+			name:          "Pre-minted token from env",
+			auth:          datadog.AzureAuth{},
+			envToken:      "env.jwt.sig",
+			expectedProof: "env.jwt.sig:12345678-1234-1234-1234-123456789012",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envToken != "" {
+				t.Setenv(datadog.AzureAccessTokenName, tc.envToken)
+			} else {
+				t.Setenv(datadog.AzureAccessTokenName, "")
+				os.Unsetenv(datadog.AzureAccessTokenName)
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/api/v2/delegated-token" {
+					t.Errorf("got path %q, want /api/v2/delegated-token", r.URL.Path)
+				}
+				if got := r.Header.Get("Authorization"); got != "Delegated "+tc.expectedProof {
+					t.Errorf("Authorization = %q, want %q", got, "Delegated "+tc.expectedProof)
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data":{"type":"delegated_token","attributes":{"access_token":"delegated.jwt.sig","expires":"1700000000"}}}`))
+			}))
+			defer server.Close()
+
+			ctx, cfg := delegatedTokenTestContext(t, server, datadog.ProviderAzure)
+			cfg.ProviderAuth = &tc.auth
+
+			creds, err := cfg.ProviderAuth.Authenticate(ctx, cfg)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error containing %v, got nil", tc.expectErrParts)
+				}
+				for _, part := range tc.expectErrParts {
+					if !strings.Contains(err.Error(), part) {
+						t.Errorf("error = %q, want it to contain %q", err.Error(), part)
+					}
+				}
+				return
+			}
+			if creds.DelegatedToken != "delegated.jwt.sig" {
+				t.Errorf("DelegatedToken = %q, want delegated.jwt.sig", creds.DelegatedToken)
+			}
+			if creds.DelegatedProof != tc.expectedProof {
+				t.Errorf("DelegatedProof = %q, want %q", creds.DelegatedProof, tc.expectedProof)
+			}
+		})
+	}
+}
+
+// TestAzureDelegatedProofSuffix pins the org-routing contract end to end: the
+// delegated-token endpoint receives `Authorization: Delegated <token>:<org-uuid>`
+// (the servicer splits on the last colon).
+func TestAzureDelegatedProofSuffix(t *testing.T) {
+	t.Setenv(datadog.AzureAccessTokenName, "")
+	os.Unsetenv(datadog.AzureAccessTokenName)
+
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"type":"delegated_token","attributes":{"access_token":"delegated.jwt.sig"}}}`))
+	}))
+	defer server.Close()
+
+	ctx, cfg := delegatedTokenTestContext(t, server, datadog.ProviderAzure)
+	cfg.ProviderAuth = &datadog.AzureAuth{AccessToken: "hdr.payload.sig"}
+
+	if _, err := cfg.ProviderAuth.Authenticate(ctx, cfg); err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if gotAuth != "Delegated hdr.payload.sig:12345678-1234-1234-1234-123456789012" {
+		t.Errorf("Authorization = %q, want suffixed org-routing proof", gotAuth)
+	}
+}
+
+func TestAzureAccessTokenPrefersFieldOverEnv(t *testing.T) {
+	t.Setenv(datadog.AzureAccessTokenName, "env.jwt.sig")
+	auth := datadog.AzureAuth{AccessToken: "field.jwt.sig"}
+	token, err := auth.GetAccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("GetAccessToken: %v", err)
+	}
+	if token != "field.jwt.sig" {
+		t.Errorf("token = %q, want field.jwt.sig", token)
+	}
+}
+
+func TestAzureContextOverride(t *testing.T) {
+	t.Setenv(datadog.AzureAccessTokenName, "env.jwt.sig")
+	ctx := context.WithValue(context.Background(), datadog.ContextAzureVariables, map[string]string{
+		datadog.AzureAccessTokenName: "ctx.jwt.sig",
+	})
+	auth := datadog.AzureAuth{}
+	token, err := auth.GetAccessToken(ctx)
+	if err != nil {
+		t.Fatalf("GetAccessToken: %v", err)
+	}
+	if token != "ctx.jwt.sig" {
+		t.Errorf("token = %q, want ctx.jwt.sig (context override wins over env)", token)
+	}
+}
+
+func TestAzureAuthenticateMissingOrgUUID(t *testing.T) {
+	auth := datadog.AzureAuth{AccessToken: "token"}
+	_, err := auth.Authenticate(context.Background(), &datadog.DelegatedTokenConfig{ProviderAuth: &auth})
+	if err == nil || !strings.Contains(err.Error(), "missing org UUID") {
+		t.Errorf("err = %v, want missing org UUID error", err)
+	}
+}

--- a/tests/api/azure_test.go
+++ b/tests/api/azure_test.go
@@ -85,9 +85,8 @@ func TestAzureAuthenticate(t *testing.T) {
 	}
 }
 
-// TestAzureDelegatedProofSuffix pins the org-routing contract end to end: the
-// delegated-token endpoint receives `Authorization: Delegated <token>:<org-uuid>`
-// (the servicer splits on the last colon).
+// TestAzureDelegatedProofSuffix verifies the organization UUID is included in
+// the delegated authentication proof sent in the Authorization header.
 func TestAzureDelegatedProofSuffix(t *testing.T) {
 	t.Setenv(datadog.AzureAccessTokenName, "")
 

--- a/tests/api/azure_test.go
+++ b/tests/api/azure_test.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -17,7 +17,6 @@ func TestAzureAuthenticate(t *testing.T) {
 		auth           datadog.AzureAuth
 		envToken       string
 		expectedProof  string
-		expectErr      bool
 		expectErrParts []string
 	}
 
@@ -34,29 +33,17 @@ func TestAzureAuthenticate(t *testing.T) {
 			expectedProof: "env.jwt.sig:12345678-1234-1234-1234-123456789012",
 		},
 		{
-			// No token anywhere: with PATH emptied below,
-			// mintAccessToken's exec.LookPath fails deterministically
-			// without invoking a real `az` binary, so the case is hermetic.
-			name:           "No token and no az CLI fails",
-			auth:           datadog.AzureAuth{},
-			expectErr:      true,
-			expectErrParts: []string{"`az` not found on PATH"},
+			name: "Token source fallback",
+			auth: datadog.AzureAuth{TokenSource: func(context.Context) (string, error) {
+				return "source.jwt.sig", nil
+			}},
+			expectedProof: "source.jwt.sig:12345678-1234-1234-1234-123456789012",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.envToken != "" {
-				t.Setenv(datadog.AzureAccessTokenName, tc.envToken)
-			} else {
-				t.Setenv(datadog.AzureAccessTokenName, "")
-				os.Unsetenv(datadog.AzureAccessTokenName)
-			}
-			if tc.expectErr {
-				// Empty PATH so exec.LookPath("az") fails deterministically
-				// on machines with the Azure CLI installed.
-				t.Setenv("PATH", "")
-			}
+			t.Setenv(datadog.AzureAccessTokenName, tc.envToken)
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path != "/api/v2/delegated-token" {
@@ -74,7 +61,7 @@ func TestAzureAuthenticate(t *testing.T) {
 			cfg.ProviderAuth = &tc.auth
 
 			creds, err := cfg.ProviderAuth.Authenticate(ctx, cfg)
-			if tc.expectErr {
+			if len(tc.expectErrParts) > 0 {
 				if err == nil {
 					t.Fatalf("expected error containing %v, got nil", tc.expectErrParts)
 				}
@@ -84,6 +71,9 @@ func TestAzureAuthenticate(t *testing.T) {
 					}
 				}
 				return
+			}
+			if err != nil {
+				t.Fatalf("Authenticate: %v", err)
 			}
 			if creds.DelegatedToken != "delegated.jwt.sig" {
 				t.Errorf("DelegatedToken = %q, want delegated.jwt.sig", creds.DelegatedToken)
@@ -100,7 +90,6 @@ func TestAzureAuthenticate(t *testing.T) {
 // (the servicer splits on the last colon).
 func TestAzureDelegatedProofSuffix(t *testing.T) {
 	t.Setenv(datadog.AzureAccessTokenName, "")
-	os.Unsetenv(datadog.AzureAccessTokenName)
 
 	var gotAuth string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -121,30 +110,46 @@ func TestAzureDelegatedProofSuffix(t *testing.T) {
 	}
 }
 
-func TestAzureAccessTokenPrefersFieldOverEnv(t *testing.T) {
-	t.Setenv(datadog.AzureAccessTokenName, "env.jwt.sig")
-	auth := datadog.AzureAuth{AccessToken: "field.jwt.sig"}
-	token, err := auth.GetAccessToken(context.Background())
-	if err != nil {
-		t.Fatalf("GetAccessToken: %v", err)
-	}
-	if token != "field.jwt.sig" {
-		t.Errorf("token = %q, want field.jwt.sig", token)
-	}
-}
-
-func TestAzureContextOverride(t *testing.T) {
+func TestAzureAccessTokenPrecedence(t *testing.T) {
 	t.Setenv(datadog.AzureAccessTokenName, "env.jwt.sig")
 	ctx := context.WithValue(context.Background(), datadog.ContextAzureVariables, map[string]string{
 		datadog.AzureAccessTokenName: "ctx.jwt.sig",
 	})
-	auth := datadog.AzureAuth{}
+	tokenSourceCalled := false
+	auth := datadog.AzureAuth{
+		AccessToken: "field.jwt.sig",
+		TokenSource: func(context.Context) (string, error) {
+			tokenSourceCalled = true
+			return "source.jwt.sig", nil
+		},
+	}
+
 	token, err := auth.GetAccessToken(ctx)
 	if err != nil {
-		t.Fatalf("GetAccessToken: %v", err)
+		t.Fatalf("GetAccessToken with field: %v", err)
+	}
+	if token != "field.jwt.sig" {
+		t.Errorf("token = %q, want field.jwt.sig", token)
+	}
+
+	auth.AccessToken = ""
+	token, err = auth.GetAccessToken(ctx)
+	if err != nil {
+		t.Fatalf("GetAccessToken with context token: %v", err)
 	}
 	if token != "ctx.jwt.sig" {
-		t.Errorf("token = %q, want ctx.jwt.sig (context override wins over env)", token)
+		t.Errorf("token = %q, want ctx.jwt.sig", token)
+	}
+
+	token, err = auth.GetAccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("GetAccessToken with environment token: %v", err)
+	}
+	if token != "env.jwt.sig" {
+		t.Errorf("token = %q, want env.jwt.sig", token)
+	}
+	if tokenSourceCalled {
+		t.Error("TokenSource called before higher-precedence sources were exhausted")
 	}
 }
 
@@ -156,100 +161,63 @@ func TestAzureAuthenticateMissingOrgUUID(t *testing.T) {
 	}
 }
 
-// writeAzShim installs a fake `az` executable that records its argv to
-// argvFile and prints a JSON access-token response on stdout, returning a
-// directory to prepend to PATH. This exercises the real mint path
-// (mintAccessToken, argument construction, output parsing) without requiring
-// the az CLI.
-func writeAzShim(t *testing.T, argvFile, token string) string {
-	t.Helper()
-	dir := t.TempDir()
-	script := "#!/bin/sh\n" +
-		"printf '%s\\n' \"$@\" >> " + argvFile + "\n" +
-		`echo '{"accessToken":"` + token + `"}'` + "\n"
-	path := dir + "/az"
-	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
-		t.Fatalf("write az shim: %v", err)
-	}
-	return dir
-}
-
-// TestAzureMintAccessTokenViaShim drives the real mint path through a fake az
-// and pins the invocation: JSON output (token extracted without depending on
-// JMESPath behavior across az versions) and no --resource when Resource is
-// unset.
-func TestAzureMintAccessTokenViaShim(t *testing.T) {
-	argvFile := t.TempDir() + "/argv"
-	const token = "shim.jwt.sig"
-	shimDir := writeAzShim(t, argvFile, token)
-	t.Setenv("PATH", shimDir)
+func TestAzureTokenSourceFallback(t *testing.T) {
 	t.Setenv(datadog.AzureAccessTokenName, "")
-	os.Unsetenv(datadog.AzureAccessTokenName)
-
-	auth := datadog.AzureAuth{}
-	got, err := auth.GetAccessToken(context.Background())
-	if err != nil {
-		t.Fatalf("GetAccessToken: %v", err)
-	}
-	if got != token {
-		t.Errorf("token = %q, want %q", got, token)
-	}
-
-	argv, err := os.ReadFile(argvFile)
-	if err != nil {
-		t.Fatalf("read shim argv: %v", err)
-	}
-	wantArgs := []string{"account", "get-access-token", "--output", "json"}
-	gotArgs := strings.Split(strings.TrimSpace(string(argv)), "\n")
-	if len(gotArgs) != len(wantArgs) {
-		t.Fatalf("az argv = %v, want %v", gotArgs, wantArgs)
-	}
-	for i := range wantArgs {
-		if gotArgs[i] != wantArgs[i] {
-			t.Errorf("az argv[%d] = %q, want %q", i, gotArgs[i], wantArgs[i])
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "context value")
+	auth := datadog.AzureAuth{TokenSource: func(sourceCtx context.Context) (string, error) {
+		if got := sourceCtx.Value(contextKey{}); got != "context value" {
+			t.Errorf("TokenSource context value = %v, want context value", got)
 		}
-	}
-}
+		return "source.jwt.sig", nil
+	}}
 
-// TestAzureMintAccessTokenResourceArg pins the --resource passthrough.
-func TestAzureMintAccessTokenResourceArg(t *testing.T) {
-	argvFile := t.TempDir() + "/argv"
-	shimDir := writeAzShim(t, argvFile, "shim.jwt.sig")
-	t.Setenv("PATH", shimDir)
-	t.Setenv(datadog.AzureAccessTokenName, "")
-	os.Unsetenv(datadog.AzureAccessTokenName)
-
-	auth := datadog.AzureAuth{Resource: "https://management.azure.com/"}
-	if _, err := auth.GetAccessToken(context.Background()); err != nil {
+	token, err := auth.GetAccessToken(ctx)
+	if err != nil {
 		t.Fatalf("GetAccessToken: %v", err)
 	}
-	argv, err := os.ReadFile(argvFile)
-	if err != nil {
-		t.Fatalf("read shim argv: %v", err)
-	}
-	if !strings.Contains(string(argv), "--resource") || !strings.Contains(string(argv), "https://management.azure.com/") {
-		t.Errorf("az argv = %q, want it to carry --resource with its value", string(argv))
+	if token != "source.jwt.sig" {
+		t.Errorf("token = %q, want source.jwt.sig", token)
 	}
 }
 
-// TestAzureMintAccessTokenShimError pins the error path: a failing az
-// surfaces its stderr in the wrapped error.
-func TestAzureMintAccessTokenShimError(t *testing.T) {
-	dir := t.TempDir()
-	script := "#!/bin/sh\necho 'run az login' >&2\nexit 1\n"
-	if err := os.WriteFile(dir+"/az", []byte(script), 0o755); err != nil {
-		t.Fatalf("write az shim: %v", err)
-	}
-	t.Setenv("PATH", dir)
+func TestAzureTokenSourceError(t *testing.T) {
 	t.Setenv(datadog.AzureAccessTokenName, "")
-	os.Unsetenv(datadog.AzureAccessTokenName)
+	sourceErr := errors.New("credential unavailable")
+	auth := datadog.AzureAuth{TokenSource: func(context.Context) (string, error) {
+		return "", sourceErr
+	}}
 
-	auth := datadog.AzureAuth{}
 	_, err := auth.GetAccessToken(context.Background())
-	if err == nil {
-		t.Fatal("expected error from failing az shim")
+	if !errors.Is(err, sourceErr) {
+		t.Fatalf("error = %v, want wrapped token source error", err)
 	}
-	if !strings.Contains(err.Error(), "run az login") {
-		t.Errorf("err = %v, want it to carry the CLI stderr", err)
+	if !strings.Contains(err.Error(), "azure token source") {
+		t.Errorf("error = %q, want TokenSource context", err.Error())
+	}
+}
+
+func TestAzureTokenSourceRejectsEmptyToken(t *testing.T) {
+	t.Setenv(datadog.AzureAccessTokenName, "")
+	auth := datadog.AzureAuth{TokenSource: func(context.Context) (string, error) {
+		return "", nil
+	}}
+
+	_, err := auth.GetAccessToken(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "empty access token") {
+		t.Fatalf("error = %v, want empty access token error", err)
+	}
+}
+
+func TestAzureAccessTokenRequiresSource(t *testing.T) {
+	t.Setenv(datadog.AzureAccessTokenName, "")
+	_, err := (&datadog.AzureAuth{}).GetAccessToken(context.Background())
+	if err == nil {
+		t.Fatal("expected missing Azure access token error")
+	}
+	for _, part := range []string{"AzureAuth.AccessToken", datadog.AzureAccessTokenName, "AzureAuth.TokenSource"} {
+		if !strings.Contains(err.Error(), part) {
+			t.Errorf("error = %q, want it to contain %q", err.Error(), part)
+		}
 	}
 }

--- a/tests/api/azure_test.go
+++ b/tests/api/azure_test.go
@@ -11,27 +11,6 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 )
 
-// delegatedTokenTestContext returns a context and DelegatedTokenConfig wired
-// so that GetDelegatedTokenUrl routes its POST /api/v2/delegated-token call at
-// the given test server, using the "{protocol}://{name}" server configuration
-// (index 1).
-func delegatedTokenTestContext(t *testing.T, server *httptest.Server, provider string) (context.Context, *datadog.DelegatedTokenConfig) {
-	t.Helper()
-
-	ctx := context.WithValue(context.Background(), datadog.ContextServerIndex, 1)
-	ctx = context.WithValue(ctx, datadog.ContextServerVariables, map[string]string{
-		"name":     server.URL[len("http://"):],
-		"protocol": "http",
-	})
-	ctx = context.WithValue(ctx, datadog.ContextDelegatedToken, &datadog.DelegatedTokenCredentials{})
-
-	cfg := &datadog.DelegatedTokenConfig{
-		OrgUUID:  "12345678-1234-1234-1234-123456789012",
-		Provider: provider,
-	}
-	return ctx, cfg
-}
-
 func TestAzureAuthenticate(t *testing.T) {
 	type testCase struct {
 		name           string

--- a/tests/api/delegated_token_testutil_test.go
+++ b/tests/api/delegated_token_testutil_test.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+)
+
+// delegatedTokenTestContext returns a context and DelegatedTokenConfig wired
+// so that GetDelegatedTokenUrl routes its POST /api/v2/delegated-token call at
+// the given test server, using the "{protocol}://{name}" server configuration
+// (index 1).
+func delegatedTokenTestContext(t *testing.T, server *httptest.Server, provider string) (context.Context, *datadog.DelegatedTokenConfig) {
+	t.Helper()
+
+	ctx := context.WithValue(context.Background(), datadog.ContextServerIndex, 1)
+	ctx = context.WithValue(ctx, datadog.ContextServerVariables, map[string]string{
+		"name":     server.URL[len("http://"):],
+		"protocol": "http",
+	})
+	ctx = context.WithValue(ctx, datadog.ContextDelegatedToken, &datadog.DelegatedTokenCredentials{})
+
+	cfg := &datadog.DelegatedTokenConfig{
+		OrgUUID:  "12345678-1234-1234-1234-123456789012",
+		Provider: provider,
+	}
+	return ctx, cfg
+}


### PR DESCRIPTION
## Summary

Adds Azure support for delegated authentication through a new `AzureAuth` provider.

Applications can provide a pre-minted Microsoft Entra ID access token or inject a `TokenSource` that acquires and renews tokens. The client does not invoke the Azure CLI or add an Azure SDK dependency.

## Review guide

The change is split into four parts:

1. `api/datadog/azure.go` defines `AzureAuth`, token resolution, and proof construction.
2. `api/datadog/configuration.go` loads `DD_AZURE_ACCESS_TOKEN` into the default context.
3. `.generator/` contains the matching templates so regeneration preserves the feature.
4. `tests/api/azure_test.go` covers token precedence, failures, and the authentication proof.

## Token resolution

`AzureAuth` resolves an access token in this order:

1. `AzureAuth.AccessToken`
2. `ContextAzureVariables` or `DD_AZURE_ACCESS_TOKEN`
3. `AzureAuth.TokenSource`

`TokenSource` has this signature:

```go
type AzureTokenSource func(context.Context) (string, error)
```

The application owns credential selection, tenant selection, audience or scope, and token renewal. This lets applications adapt Managed Identity, Workload Identity, or an explicitly selected developer credential without making those choices inside the API client.

## Authentication flow

After resolving the access token, `AzureAuth` includes the Datadog organization UUID in the Azure delegated authentication proof and exchanges it for a Datadog delegated token through the existing `DelegatedTokenProvider` interface.

## Usage

Using a pre-minted token from `DD_AZURE_ACCESS_TOKEN`:

```go
configuration := datadog.NewConfiguration()
configuration.DelegatedTokenConfig = &datadog.DelegatedTokenConfig{
    OrgUUID:      orgUUID,
    ProviderAuth: &datadog.AzureAuth{},
    Provider:     datadog.ProviderAzure,
}
```

Using application-managed token acquisition:

```go
configuration.DelegatedTokenConfig.ProviderAuth = &datadog.AzureAuth{
    TokenSource: applicationAzureTokenSource,
}
```

`applicationAzureTokenSource` is any `func(context.Context) (string, error)` that returns a current Microsoft Entra ID access token.

## Testing

`tests/api/azure_test.go` covers:

- End-to-end proof construction
- Field, context, environment, and token-source precedence
- Context forwarding to `TokenSource`
- Wrapped token-source errors
- Empty-token rejection
- Missing-source and missing-organization errors

Verified with:

- `go test ./api -run '^TestAzure'` from the `tests` module
- `go test ./api/datadog`
- `go test ./examples/datadog/azure`

## Related change

PR #4590 adds the corresponding GCP provider. The two PRs may have small mechanical conflicts in shared generator and configuration maps if merged out of order.
